### PR TITLE
Fix saving filterImage to the cache instead of image

### DIFF
--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -299,7 +299,7 @@ public class ImageDownloader {
                             }
 
                             strongSelf.imageCache?.addImage(
-                                image,
+                                filteredImage,
                                 forRequest: request,
                                 withAdditionalIdentifier: filter?.identifier
                             )


### PR DESCRIPTION
When an image is added to the cache with a filter applied it is stored
with the identifier including the filter-identifier, but the original
image is stored.