### PR TITLE
Composite filters

### DIFF
--- a/Source/ImageFilter.swift
+++ b/Source/ImageFilter.swift
@@ -78,17 +78,6 @@ extension ImageFilter where Self: Roundable {
     }
 }
 
-extension ImageFilter where Self: Sizable, Self: Roundable {
-    /// The unique idenitifier for an `ImageFilter` conforming to both the `Sizable` and `Roundable` protocols.
-    public var identifier: String {
-        let width = Int64(round(size.width))
-        let height = Int64(round(size.height))
-        let radius = Int64(round(self.radius))
-
-        return "\(self.dynamicType)-size:(\(width)x\(height))-radius:(\(radius))"
-    }
-}
-
 #if os(iOS) || os(watchOS)
 
 // MARK: - Single Pass Image Filters (iOS and watchOS only) -
@@ -275,13 +264,7 @@ public extension CompositeImageFilter {
 // MARK: -
 
 /// Scales an image to a specified size, then rounds the corners to the specified radius.
-public struct ScaledToSizeWithRoundedCornersFilter: CompositeImageFilter, Sizable, Roundable {
-    /// The size of the filter.
-    public let size: CGSize
-
-    /// The radius of the filter.
-    public let radius: CGFloat
-
+public struct ScaledToSizeWithRoundedCornersFilter: CompositeImageFilter {
     /**
         Initializes the `ScaledToSizeWithRoundedCornersFilter` instance with the given size and radius.
 
@@ -291,8 +274,6 @@ public struct ScaledToSizeWithRoundedCornersFilter: CompositeImageFilter, Sizabl
         - returns: The new `ScaledToSizeWithRoundedCornersFilter` instance.
     */
     public init(size: CGSize, radius: CGFloat) {
-        self.size = size
-        self.radius = radius
         self.filters = [ScaledToSizeFilter(size: size), RoundedCornersFilter(radius: radius)]
     }
     
@@ -305,13 +286,7 @@ public struct ScaledToSizeWithRoundedCornersFilter: CompositeImageFilter, Sizabl
 
 /// Scales an image from the center while maintaining the aspect ratio to fit within a specified size, then rounds the 
 /// corners to the specified radius.
-public struct AspectScaledToFillSizeWithRoundedCornersFilter: CompositeImageFilter, Sizable, Roundable {
-    /// The size of the filter.
-    public let size: CGSize
-
-    /// The radius of the filter.
-    public let radius: CGFloat
-
+public struct AspectScaledToFillSizeWithRoundedCornersFilter: CompositeImageFilter {
     /**
         Initializes the `AspectScaledToFillSizeWithRoundedCornersFilter` instance with the given size and radius.
 
@@ -321,8 +296,6 @@ public struct AspectScaledToFillSizeWithRoundedCornersFilter: CompositeImageFilt
         - returns: The new `AspectScaledToFillSizeWithRoundedCornersFilter` instance.
     */
     public init(size: CGSize, radius: CGFloat) {
-        self.size = size
-        self.radius = radius
         self.filters = [AspectScaledToFillSizeFilter(size: size), RoundedCornersFilter(radius: radius)]
     }
     
@@ -333,13 +306,7 @@ public struct AspectScaledToFillSizeWithRoundedCornersFilter: CompositeImageFilt
 // MARK: -
 
 /// Scales an image to a specified size, then rounds the corners into a circle.
-public struct ScaledToSizeCircleFilter: CompositeImageFilter, Sizable, Roundable {
-    /// The size of the filter.
-    public let size: CGSize
-
-    /// The radius of the filter.
-    public let radius: CGFloat
-
+public struct ScaledToSizeCircleFilter: CompositeImageFilter {
     /**
         Initializes the `ScaledToSizeCircleFilter` instance with the given size.
 
@@ -348,8 +315,6 @@ public struct ScaledToSizeCircleFilter: CompositeImageFilter, Sizable, Roundable
         - returns: The new `ScaledToSizeCircleFilter` instance.
     */
     public init(size: CGSize) {
-        self.size = size
-        self.radius = min(size.width, size.height) / 2.0
         self.filters = [ScaledToSizeFilter(size: size), CircleFilter()]
     }
     
@@ -361,13 +326,7 @@ public struct ScaledToSizeCircleFilter: CompositeImageFilter, Sizable, Roundable
 
 /// Scales an image from the center while maintaining the aspect ratio to fit within a specified size, then rounds the
 /// corners into a circle.
-public struct AspectScaledToFillSizeCircleFilter: CompositeImageFilter, Sizable, Roundable {
-    /// The size of the filter.
-    public let size: CGSize
-
-    /// The radius of the filter.
-    public let radius: CGFloat
-
+public struct AspectScaledToFillSizeCircleFilter: CompositeImageFilter {
     /**
         Initializes the `AspectScaledToFillSizeCircleFilter` instance with the given size.
 
@@ -376,8 +335,6 @@ public struct AspectScaledToFillSizeCircleFilter: CompositeImageFilter, Sizable,
         - returns: The new `AspectScaledToFillSizeCircleFilter` instance.
     */
     public init(size: CGSize) {
-        self.size = size
-        self.radius = min(size.width, size.height) / 2.0
         self.filters = [AspectScaledToFillSizeFilter(size: size), CircleFilter()]
     }
     

--- a/Source/ImageFilter.swift
+++ b/Source/ImageFilter.swift
@@ -246,6 +246,32 @@ public struct BlurFilter: ImageFilter {
 
 #endif
 
+// MARK: - Composite Image Filters (iOS and watchOS only) -
+
+/// The `CompositeImageFilter` protocol defines an additional filter property for filter components.
+public protocol CompositeImageFilter: ImageFilter {
+    
+    /// The filters composing the receiver filter.
+    var filters: [ImageFilter] { get }
+    
+}
+    
+public extension CompositeImageFilter {
+    
+    /// The unique idenitifier for any `CompositeImageFilter` type.
+    var identifier: String {
+        return filters.map { $0.identifier }.joinWithSeparator("_")
+    }
+    
+    /// The filter closure for any `CompositeImageFilter` type.
+    var filter: Image -> Image {
+        return { image in
+            return self.filters.reduce(image) { $1.filter($0) }
+        }
+    }
+    
+}
+    
 // MARK: - Multi-Pass Image Filters (iOS and watchOS only) -
 
 /// Scales an image to a specified size, then rounds the corners to the specified radius.

--- a/Source/ImageFilter.swift
+++ b/Source/ImageFilter.swift
@@ -272,10 +272,10 @@ public extension CompositeImageFilter {
     
 }
     
-// MARK: - Multi-Pass Image Filters (iOS and watchOS only) -
+// MARK: -
 
 /// Scales an image to a specified size, then rounds the corners to the specified radius.
-public struct ScaledToSizeWithRoundedCornersFilter: ImageFilter, Sizable, Roundable {
+public struct ScaledToSizeWithRoundedCornersFilter: CompositeImageFilter, Sizable, Roundable {
     /// The size of the filter.
     public let size: CGSize
 
@@ -293,24 +293,19 @@ public struct ScaledToSizeWithRoundedCornersFilter: ImageFilter, Sizable, Rounda
     public init(size: CGSize, radius: CGFloat) {
         self.size = size
         self.radius = radius
+        self.filters = [ScaledToSizeFilter(size: size), RoundedCornersFilter(radius: radius)]
     }
+    
+    /// The filters composing the receiver filter.
+    public let filters: [ImageFilter]
 
-    /// The filter closure used to create the modified representation of the given image.
-    public var filter: Image -> Image {
-        return { image in
-            let scaledImage = image.af_imageScaledToSize(self.size)
-            let roundedAndScaledImage = scaledImage.af_imageWithRoundedCornerRadius(self.radius * image.scale)
-
-            return roundedAndScaledImage
-        }
-    }
 }
 
 // MARK: -
 
 /// Scales an image from the center while maintaining the aspect ratio to fit within a specified size, then rounds the 
 /// corners to the specified radius.
-public struct AspectScaledToFillSizeWithRoundedCornersFilter: ImageFilter, Sizable, Roundable {
+public struct AspectScaledToFillSizeWithRoundedCornersFilter: CompositeImageFilter, Sizable, Roundable {
     /// The size of the filter.
     public let size: CGSize
 
@@ -328,23 +323,17 @@ public struct AspectScaledToFillSizeWithRoundedCornersFilter: ImageFilter, Sizab
     public init(size: CGSize, radius: CGFloat) {
         self.size = size
         self.radius = radius
+        self.filters = [AspectScaledToFillSizeFilter(size: size), RoundedCornersFilter(radius: radius)]
     }
-
-    /// The filter closure used to create the modified representation of the given image.
-    public var filter: Image -> Image {
-        return { image in
-            let scaledImage = image.af_imageAspectScaledToFillSize(self.size)
-            let roundedAndScaledImage = scaledImage.af_imageWithRoundedCornerRadius(self.radius * image.scale)
-
-            return roundedAndScaledImage
-        }
-    }
+    
+    /// The filters composing the receiver filter.
+    public let filters: [ImageFilter]
 }
 
 // MARK: -
 
 /// Scales an image to a specified size, then rounds the corners into a circle.
-public struct ScaledToSizeCircleFilter: ImageFilter, Sizable, Roundable {
+public struct ScaledToSizeCircleFilter: CompositeImageFilter, Sizable, Roundable {
     /// The size of the filter.
     public let size: CGSize
 
@@ -361,24 +350,18 @@ public struct ScaledToSizeCircleFilter: ImageFilter, Sizable, Roundable {
     public init(size: CGSize) {
         self.size = size
         self.radius = min(size.width, size.height) / 2.0
+        self.filters = [ScaledToSizeFilter(size: size), CircleFilter()]
     }
-
-    /// The filter closure used to create the modified representation of the given image.
-    public var filter: Image -> Image {
-        return { image in
-            let scaledImage = image.af_imageScaledToSize(self.size)
-            let scaledCircleImage = scaledImage.af_imageRoundedIntoCircle()
-            
-            return scaledCircleImage
-        }
-    }
+    
+    /// The filters composing the receiver filter.
+    public let filters: [ImageFilter]
 }
 
 // MARK: -
 
 /// Scales an image from the center while maintaining the aspect ratio to fit within a specified size, then rounds the
 /// corners into a circle.
-public struct AspectScaledToFillSizeCircleFilter: ImageFilter, Sizable, Roundable {
+public struct AspectScaledToFillSizeCircleFilter: CompositeImageFilter, Sizable, Roundable {
     /// The size of the filter.
     public let size: CGSize
 
@@ -395,17 +378,11 @@ public struct AspectScaledToFillSizeCircleFilter: ImageFilter, Sizable, Roundabl
     public init(size: CGSize) {
         self.size = size
         self.radius = min(size.width, size.height) / 2.0
+        self.filters = [AspectScaledToFillSizeFilter(size: size), CircleFilter()]
     }
-
-    /// The filter closure used to create the modified representation of the given image.
-    public var filter: Image -> Image {
-        return { image in
-            let scaledImage = image.af_imageAspectScaledToFillSize(self.size)
-            let scaledCircleImage = scaledImage.af_imageRoundedIntoCircle()
-            
-            return scaledCircleImage
-        }
-    }
+    
+    /// The filters composing the receiver filter.
+    public let filters: [ImageFilter]
 }
 
 #endif

--- a/Tests/ImageFilterTests.swift
+++ b/Tests/ImageFilterTests.swift
@@ -30,7 +30,7 @@ class ImageFilterTestCase: BaseTestCase {
     let largeSquareSize = CGSize(width: 100, height: 100)
     let scale = Int(round(UIScreen.mainScreen().scale))
 
-    // MARK: - Protocol Extension Identifiers
+    // MARK: - ImageFilter Protocol Extension Identifiers
 
     func testThatImageFilterIdentifierIsImplemented() {
         // Given
@@ -64,18 +64,20 @@ class ImageFilterTestCase: BaseTestCase {
         // Then
         XCTAssertEqual(identifier, "RoundedCornersFilter-radius:(12)", "identifier does not match expected value")
     }
-
-    func testThatImageFilterWhereSelfIsSizableAndRoundableIdentifierIsImplemented() {
+    
+    // MARK: - CompositeImageFilter Protocol Extension Identifiers
+    
+    func testThatCompositeImageFilterIdentifierIsImplemented() {
         // Given
         let filter = ScaledToSizeWithRoundedCornersFilter(size: CGSize(width: 200, height: 100), radius: 20.0123)
-
+        
         // When
         let identifier = filter.identifier
-
+        
         // Then
         XCTAssertEqual(
             identifier,
-            "ScaledToSizeWithRoundedCornersFilter-size:(200x100)-radius:(20)",
+            "ScaledToSizeFilter-size:(200x100)_RoundedCornersFilter-radius:(20)",
             "identifier does not match expected value"
         )
     }
@@ -163,7 +165,7 @@ class ImageFilterTestCase: BaseTestCase {
         XCTAssertTrue(pixelsMatch, "pixels match should be true")
     }
 
-    // MARK: - Multi-Pass Image Filter Tests
+    // MARK: - Composite Image Filter Tests
 
     func testThatScaledToSizeWithRoundedCornersFilterReturnsCorrectFilteredImage() {
         // Given


### PR DESCRIPTION
I have added a `CompositeImageFilter` protocol and adapted multi-pass filters to conform to this new protocol.

**Note:**
There is one issue with `testThatScaledToSizeWithRoundedCornersFilterReturnsCorrectFilteredImage` and `testThatAspectScaledToFillSizeWithRoundedCornersFilterReturnsCorrectFilteredImage` tests. Previous version of the tests multi-pass filters used to multiply the corner radius with the input image's scale. This is something that cannot be done with composite filters, except if `RoundedCornersFilter` automatically uses the image scale in its filter closure (`image.af_imageWithRoundedCornerRadius(self.radius * image.scale)`). I tried this, but in that case, `testThatRoundedCornersFilterReturnsCorrectFilteredImage` test does not pass.
Do you have any idea about how to solve this issue?