### PR TITLE
Update podspec to Alamofire 2.0.1

### DIFF
--- a/AlamofireImage.podspec
+++ b/AlamofireImage.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.9'
   s.watchos.deployment_target = '2.0'
 
-  s.dependency 'Alamofire', '2.0.0'
+  s.dependency 'Alamofire', '2.0.1'
 end


### PR DESCRIPTION
To stop errors on pod install 
```
[!] Unable to satisfy the following requirements:

- `Alamofire (~> 2.0)` required by `Podfile`
- `Alamofire (= 2.0.1)` required by `Podfile.lock`
- `Alamofire (= 2.0.0)` required by `AlamofireImage (1.0.0)`
- `AlamofireImage` required by `Podfile
````