### PR TITLE
Dynamic image filters (single & composite)

### DIFF
--- a/Source/ImageFilter.swift
+++ b/Source/ImageFilter.swift
@@ -40,7 +40,7 @@ public protocol ImageFilter {
 }
 
 extension ImageFilter {
-    /// The unique idenitifier for any `ImageFilter` type.
+    /// The unique identifier for any `ImageFilter` type.
     public var identifier: String { return "\(self.dynamicType)" }
 }
 
@@ -75,6 +75,29 @@ extension ImageFilter where Self: Roundable {
     public var identifier: String {
         let radius = Int64(round(self.radius))
         return "\(self.dynamicType)-radius:(\(radius))"
+    }
+}
+
+// MARK: - Dynamic Filter
+
+/// The `DynamicImageFilter` class is an image filter based on a given closure and a unique identifier.
+public struct DynamicImageFilter: ImageFilter {
+    /// A closure used to create an alternative representation of the given image.
+    public let filter: Image -> Image
+    /// The string used to uniquely identify the filter operation.
+    public let identifier: String
+    
+    /**
+    Initializes the `DynamicImageFilter` instance with the given identifier and filter closure.
+    
+    - parameter identifier: The unique identifier of the filter.
+    - parameter filter: A closure used to create an alternative representation of the given image.
+    
+    - returns: The new `DynamicImageFilter` instance.
+    */
+    public init(_ identifier: String, filter: Image -> Image) {
+        self.identifier = identifier
+        self.filter = filter
     }
 }
 
@@ -272,6 +295,36 @@ public extension CompositeImageFilter {
         return { image in
             return self.filters.reduce(image) { $1.filter($0) }
         }
+    }
+}
+    
+// MARK: - Dynamic Composite Filter
+
+/// The `DynamicCompositeImageFilter` class is an image filter based on a given closure and a unique identifier.
+public struct DynamicCompositeImageFilter: CompositeImageFilter {
+    /// The image filters to apply to the image in sequential order.
+    public let filters: [ImageFilter]
+    
+    /**
+    Initializes the `DynamicCompositeImageFilter` instance with the given filters.
+    
+    - parameter filters: The filters taking part in the composite image filter.
+    
+    - returns: The new `DynamicCompositeImageFilter` instance.
+    */
+    public init(_ filters: [ImageFilter]) {
+        self.filters = filters
+    }
+    
+    /**
+    Initializes the `DynamicCompositeImageFilter` instance with the given filters.
+    
+    - parameter filters: The filters taking part in the composite image filter.
+    
+    - returns: The new `DynamicCompositeImageFilter` instance.
+    */
+    public init(_ filters: ImageFilter...) {
+        self.init(filters)
     }
 }
 

--- a/Tests/ImageFilterTests.swift
+++ b/Tests/ImageFilterTests.swift
@@ -79,6 +79,55 @@ class ImageFilterTestCase: BaseTestCase {
         let expectedIdentifier = "ScaledToSizeFilter-size:(200x100)_RoundedCornersFilter-radius:(20)-divided:(false)"
         XCTAssertEqual(identifier, expectedIdentifier, "identifier does not match expected value")
     }
+    
+    // MARK: - DynamicImageFilter tests
+    
+    func testThatDynamicImageFilterIdentifierIsImplemented() {
+        let expectedIdentifier = "DynamicFilter"
+        
+        // Given
+        let filter = DynamicImageFilter(expectedIdentifier) { $0 }
+        
+        // When
+        let identifier = filter.identifier
+        
+        // Then
+        XCTAssertEqual(identifier, expectedIdentifier, "identifier does not match expected value")
+    }
+    
+    func testThatDynamicImageFilterReturnsCorrectFilteredImage() {
+        // Given
+        let image = imageForResource("pirate", withExtension: "jpg")
+        let filter = DynamicImageFilter("DynamicScaleToSizeFilter") { image in
+            return image.af_imageScaledToSize(CGSize(width: 50.0, height: 50.0))
+        }
+        
+        // When
+        let filteredImage = filter.filter(image)
+        
+        // Then
+        let expectedFilteredImage = imageForResource("pirate-scaled-50x50-@\(scale)x", withExtension: "png")
+        XCTAssertTrue(filteredImage.af_isEqualToImage(expectedFilteredImage), "filtered image pixels do not match")
+    }
+    
+    // MARK: - DynamicCompositeImageFilter tests
+    
+    func testThatDynamicCompositeImageFilterReturnsCorrectFilteredImage() {
+        // Given
+        let image = imageForResource("pirate", withExtension: "jpg")
+        let filter = DynamicCompositeImageFilter(ScaledToSizeFilter(size: largeSquareSize), RoundedCornersFilter(radius: 20))
+        
+        // When
+        let filteredImage = filter.filter(image)
+        
+        // Then
+        let expectedFilteredImage = imageForResource(
+            "pirate-scaled.to.size.with.rounded.corners-100x100x20-@\(scale)x",
+            withExtension: "png"
+        )
+        
+        XCTAssertTrue(filteredImage.af_isEqualToImage(expectedFilteredImage), "filtered image pixels do not match")
+    }
 
     // MARK: - Single Pass Image Filter Tests
 


### PR DESCRIPTION
I added two types: `DynamicImageFilter` and `DynamicCompositeImageFilter` (see issue #7).
- `DynamicImageFilter` lets you create a filter based on a closure (an explicit identifier must be provided).
- `DynamicCompositeImageFilter` lets you create a composite filter based on an array of `ImageFilter` objects.
I added tests as well.

As always, don't hesitate to reword things if needed (your english is far better than mine). Especially, take a look at the doc comments because they are mainly based on `ImageFilter` and `CompositeImageFilter` protocols' documentation.