### PR TITLE
Allow redirecting urls to work

### DIFF
--- a/Source/UIImageView+AlamofireImage.swift
+++ b/Source/UIImageView+AlamofireImage.swift
@@ -322,7 +322,7 @@ extension UIImageView {
 
                 // Ignore the event if the response request does not match the current request
                 guard let
-                    currentRequest = strongSelf.af_activeRequest?.task.currentRequest
+                    currentRequest = strongSelf.af_activeRequest?.task.originalRequest
                     where currentRequest.URLString == request?.URLString else
                 {
                     return


### PR DESCRIPTION
This fixes #15 ensuring this check does not fail due to server redirection.