### PR TITLE
Automatically validate file URLs

### DIFF
--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -65,8 +65,8 @@ extension Request {
             guard let validData = data where validData.length > 0 else {
                 return .Failure(data, Request.imageDataError())
             }
-
-            guard Request.validateResponse(response) else {
+            
+            guard Request.validateResponse(request, response: response) else {
                 return .Failure(data, Request.contentTypeValidationError())
             }
 
@@ -184,7 +184,13 @@ extension Request {
 
     // MARK: - Private - Shared Helper Methods
 
-    private class func validateResponse(response: NSHTTPURLResponse?) -> Bool {
+    private class func validateResponse(request: NSURLRequest?, response: NSHTTPURLResponse?) -> Bool {
+        
+        // allow file URLs to pass validation
+        if let url = request?.URL where url.fileURL == true {
+            return true
+        }
+        
         let acceptableContentTypes: Set<String> = [
             "image/tiff",
             "image/jpeg",

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -110,6 +110,47 @@ class RequestTestCase: BaseTestCase {
             XCTFail("result image should not be nil")
         }
     }
+    
+    func testThatImageResponseSerializerCanDownloadImageFromFileURL() {
+        // Given
+        let URL = URLForResource("apple", withExtension: "jpg")
+        let expectation = expectationWithDescription("Request should return JPG response image")
+        
+        var request: NSURLRequest?
+        var response: NSHTTPURLResponse?
+        var result: Result<Image>?
+        
+        // When
+        manager.request(.GET, URL)
+            .responseImage { responseRequest, responseResponse, responseResult in
+                request = responseRequest
+                response = responseResponse
+                result = responseResult
+                
+                expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertNotNil(request, "request should not be nil")
+        XCTAssertNil(response, "response should be nil")
+        XCTAssertTrue(result?.isSuccess ?? false, "result should be success")
+        
+        if let result = result, let image = result.value {
+            #if os(iOS)
+                let screenScale = UIScreen.mainScreen().scale
+                let expectedSize = CGSize(width: CGFloat(180) / screenScale, height: CGFloat(260) / screenScale)
+                XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
+                XCTAssertEqual(image.scale, screenScale, "image scale does not match expected value")
+                #elseif os(OSX)
+                let expectedSize = CGSize(width: 180.0, height: 260.0)
+                XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
+            #endif
+        } else {
+            XCTFail("result image should not be nil")
+        }
+    }
 
 #if os(iOS)
 


### PR DESCRIPTION
This PR is in response to https://github.com/Alamofire/AlamofireImage/issues/18

There is no response object when loading from file URLs, but the data is available to use. We should check that the request URL is a file URL and return `true` in the validation function. 