### PR TITLE
Fix completion handler cache image setting

### DIFF
--- a/Source/UIImageView+AlamofireImage.swift
+++ b/Source/UIImageView+AlamofireImage.swift
@@ -301,12 +301,8 @@ extension UIImageView {
 
         // Use the image from the image cache if it exists
         if let image = imageCache?.imageForRequest(URLRequest.URLRequest, withAdditionalIdentifier: filter?.identifier) {
-            if let completion = completion {
-                completion(URLRequest.URLRequest, nil, .Success(image))
-            } else {
-                self.image = image
-            }
-
+            completion?(URLRequest.URLRequest, nil, .Success(image))
+            self.image = image
             return
         }
 

--- a/Tests/UIImageViewTests.swift
+++ b/Tests/UIImageViewTests.swift
@@ -486,6 +486,41 @@ class UIImageViewTestCase: BaseTestCase {
         XCTAssertTrue(result?.isSuccess ?? false, "result should be a success case")
     }
 
+    func testThatImageIsSetWhenReturnedFromCacheAndCompletionHandlerSet() {
+            // Given
+            let imageView = UIImageView()
+            let URLRequest: NSURLRequest = {
+                let request = NSMutableURLRequest(URL: URL)
+                request.addValue("image/*", forHTTPHeaderField: "Accept")
+                return request
+                }()
+
+            let downloadExpectation = expectationWithDescription("image download should succeed")
+
+            // When
+            UIImageView.af_sharedImageDownloader.downloadImage(URLRequest: URLRequest) { (_, _, _) -> Void in
+                downloadExpectation.fulfill()
+            }
+            waitForExpectationsWithTimeout(timeout, handler: nil)
+
+            let cachedExpectation = expectationWithDescription("image should be cached")
+            var result: Result<UIImage>?
+            imageView.af_setImageWithURLRequest(
+                URLRequest,
+                placeholderImage: nil,
+                filter: nil,
+                imageTransition: .None,
+                completion: { _, _, responseResult in
+                    result = responseResult
+                    cachedExpectation.fulfill()
+                }
+            )
+            waitForExpectationsWithTimeout(timeout, handler: nil)
+            
+            // Then
+            XCTAssertEqual(result?.value, imageView.image)
+    }
+
     // MARK: - Cancellation
 
     func testThatImageDownloadCanBeCancelled() {


### PR DESCRIPTION
Fixed an issue from the following conditions:

* Image was in the cache
* A completion handler was provided to the image view

Before the fix, the image would not be set. After the fix, the image is now properly set, even if you provide a completion handler.