### PR TITLE
Feature - Custom Image Downloader for UIImageView

### DIFF
--- a/Tests/UIImageViewTests.swift
+++ b/Tests/UIImageViewTests.swift
@@ -132,7 +132,34 @@ class UIImageViewTestCase: BaseTestCase {
 
         // Then
         XCTAssertTrue(imageDownloadComplete, "image download complete should be true")
+    }
+
+    // MARK: - Image Downloaders
+
+    func testThatInstanceImageDownloaderOverridesSharedImageDownloader() {
+        // Given
+        let expectation = expectationWithDescription("image should download successfully")
+        var imageDownloadComplete = false
+
+        let imageView = TestImageView {
+            imageDownloadComplete = true
+            expectation.fulfill()
+        }
+
+        let configuration = NSURLSessionConfiguration.ephemeralSessionConfiguration()
+        let imageDownloader = ImageDownloader(configuration: configuration)
+        imageView.af_imageDownloader = imageDownloader
+
+        // When
+        imageView.af_setImageWithURL(URL)
+        let activeRequestCount = imageDownloader.activeRequestCount
+
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+
+        // Then
+        XCTAssertTrue(imageDownloadComplete, "image download complete should be true")
         XCTAssertNil(imageView.af_activeRequestReceipt, "active request receipt should be nil after download completes")
+        XCTAssertEqual(activeRequestCount, 1, "active request count should be 1")
     }
 
     // MARK: - Image Cache


### PR DESCRIPTION
This PR adds an `af_imageDownloader` property to the UIImageView extension allowing users to use a custom `ImageDownloader` for image views that need to be handled differently. A good example of this would be images behind different basic auth credentials than the rest of your app.

This is an alternate solution to the `ImageDownloaderDelegate` approach proposed in PR #26. Overall I think this is a much better way to approach the problem.