### PR TITLE
Feature - New ImageDownloader Initializer Accepting Manager

### DIFF
--- a/Tests/ImageDownloaderTests.swift
+++ b/Tests/ImageDownloaderTests.swift
@@ -87,6 +87,17 @@ class ImageDownloaderTestCase: BaseTestCase {
         XCTAssertNil(downloader, "downloader should be nil")
     }
 
+    func testThatImageDownloaderCanBeInitializedWithManagerInstanceAndDeinitialized() {
+        // Given
+        var downloader: ImageDownloader? = ImageDownloader(sessionManager: Manager())
+
+        // When
+        downloader = nil
+
+        // Then
+        XCTAssertNil(downloader, "downloader should be nil")
+    }
+
     func testThatImageDownloaderCanBeInitializedAndDeinitializedWithActiveDownloads() {
         // Given
         var downloader: ImageDownloader? = ImageDownloader()


### PR DESCRIPTION
This PR adds the ability for the `ImageDownloader` to accept a custom Alamofire `Manager` instance directly rather than having to initialize one from an `NSURLSessionConfiguration`. When using this in tandem with the new initializers in Alamofire 3.0, the user now has FULL control over all the `NSURLSession` initialization.

> Default behavior here is still exactly the same. This just adds a new custom initializer.