### PR TITLE
Update master spec repository before linting in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,5 +65,6 @@ script:
 
   # Run `pod lib lint` if specified
   - if [ $POD_LINT == "YES" ]; then
+      pod repo update master;
       pod lib lint --verbose;
     fi


### PR DESCRIPTION
Since AlamofireImage has dependencies, we must update the spec repository beforehand to make sure the correct versions of Alamofire will be available during lint to make the build pass.