### PR TITLE
Add a method to enqueue multiple image downloads.

### DIFF
--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -424,22 +424,13 @@ public class ImageDownloader {
      */
     public func downloadImages(
         URLRequests URLRequests: [URLRequestConvertible],
-        filter: ImageFilter?,
-        completion: CompletionHandler? )
+        filter: ImageFilter? = nil,
+        completion: CompletionHandler? = nil)
         -> [RequestReceipt]
     {
-        var receipts: [RequestReceipt] = []
-        
-        for request in URLRequests {
-            if let receipt = downloadImage(
-                URLRequest: request,
-                filter: filter,
-                completion: completion) {
-                    receipts.append(receipt)
-            }
+        return URLRequests.flatMap {
+            downloadImage(URLRequest: $0, filter: filter, completion: completion)
         }
-        
-        return receipts
     }
 
     /**

--- a/Tests/ImageDownloaderTests.swift
+++ b/Tests/ImageDownloaderTests.swift
@@ -175,6 +175,40 @@ class ImageDownloaderTestCase: BaseTestCase {
         XCTAssertTrue(result1?.isSuccess ?? false, "result 1 should be a success case")
         XCTAssertTrue(result2?.isSuccess ?? false, "result 2 should be a success case")
     }
+    
+    func testThatItCanEnqueueMultipleImages() {
+        // Given
+        let downloader = ImageDownloader()
+        
+        let download1 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download2 = URLRequest(.GET, "https://httpbin.org/image/png")
+
+        let expectation = expectationWithDescription("both downloads should succeed")
+        var completedDownloads = 0
+        
+        var results: [Result<Image, NSError>] = []
+        
+        // When
+        downloader.downloadImages(URLRequests: [download1, download2], filter: nil) { closureResponse in
+            results.append(closureResponse.result)
+            
+            completedDownloads++
+            
+            if completedDownloads == 2 {
+                expectation.fulfill()
+            }
+        }
+        
+        let activeRequestCount = downloader.activeRequestCount
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertEqual(activeRequestCount, 2, "active request count should be 2")
+        
+        XCTAssertTrue(results[0].isSuccess, "the first result should be a success case")
+        XCTAssertTrue(results[1].isSuccess, "the second result should be a success case")
+    }
 
     func testThatItDoesNotExceedTheMaximumActiveDownloadsLimit() {
         // Given


### PR DESCRIPTION
We often like to pre-populate image caches so that images are already downloaded when the user gets to a part of our apps. This PR adds a method to do that to the `ImageDownloader` class.