### PR TITLE
Added extension to UIButton to  support remote images

### DIFF
--- a/AlamofireImage.xcodeproj/project.pbxproj
+++ b/AlamofireImage.xcodeproj/project.pbxproj
@@ -468,6 +468,8 @@
 		4CEBB5411B93C622001391DE /* ImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEBB53F1B93C622001391DE /* ImageCacheTests.swift */; };
 		4CFC0A061AB4FEC90004D0B8 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFC0A051AB4FEC90004D0B8 /* ImageCache.swift */; };
 		4CFC0A091AB52BD90004D0B8 /* ImageFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFC0A081AB52BD90004D0B8 /* ImageFilter.swift */; };
+		CF24CF421C253CB100904E85 /* UIButton+AlamofireImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF24CF411C253CB100904E85 /* UIButton+AlamofireImage.swift */; };
+		CF24CF461C253D4F00904E85 /* UIButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF24CF3C1C253CA000904E85 /* UIButtonTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -734,6 +736,8 @@
 		4CEBB53F1B93C622001391DE /* ImageCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheTests.swift; sourceTree = "<group>"; };
 		4CFC0A051AB4FEC90004D0B8 /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		4CFC0A081AB52BD90004D0B8 /* ImageFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageFilter.swift; sourceTree = "<group>"; };
+		CF24CF3C1C253CA000904E85 /* UIButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonTests.swift; sourceTree = "<group>"; };
+		CF24CF411C253CB100904E85 /* UIButton+AlamofireImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIButton+AlamofireImage.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -856,6 +860,7 @@
 				4C5874851B93F81800407E58 /* ImageDownloaderTests.swift */,
 				4C5872C91B93DEAC00407E58 /* ImageFilterTests.swift */,
 				4C0897EA1B93BC0D005125D9 /* RequestTests.swift */,
+				CF24CF3C1C253CA000904E85 /* UIButtonTests.swift */,
 				4C0893F41B937404005125D9 /* UIImageTests.swift */,
 				4C62D30F1B96C1500011B036 /* UIImageViewTests.swift */,
 				4C0893EA1B936A4D005125D9 /* Extensions */,
@@ -1140,6 +1145,7 @@
 		4CF6CC5D1AAD2822007A38CB /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				CF24CF411C253CB100904E85 /* UIButton+AlamofireImage.swift */,
 				4C53084F1AB561BF0051DBAC /* UIImage+AlamofireImage.swift */,
 				4C78EA711AACD28C002C0569 /* UIImageView+AlamofireImage.swift */,
 			);
@@ -1941,6 +1947,7 @@
 				4C82907A1B927CE6005E24C8 /* Image.swift in Sources */,
 				4C96A4781AAE9488008AE0B6 /* ImageDownloader.swift in Sources */,
 				4CFC0A091AB52BD90004D0B8 /* ImageFilter.swift in Sources */,
+				CF24CF421C253CB100904E85 /* UIButton+AlamofireImage.swift in Sources */,
 				4C78EA721AACD28C002C0569 /* UIImageView+AlamofireImage.swift in Sources */,
 				4C5308501AB561BF0051DBAC /* UIImage+AlamofireImage.swift in Sources */,
 				4CFC0A061AB4FEC90004D0B8 /* ImageCache.swift in Sources */,
@@ -1953,6 +1960,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C62D3101B96C1500011B036 /* UIImageViewTests.swift in Sources */,
+				CF24CF461C253D4F00904E85 /* UIButtonTests.swift in Sources */,
 				4C0897EB1B93BC0D005125D9 /* RequestTests.swift in Sources */,
 				4C5872CA1B93DEAC00407E58 /* ImageFilterTests.swift in Sources */,
 				4CEBB5401B93C622001391DE /* ImageCacheTests.swift in Sources */,

--- a/Source/UIButton+AlamofireImage.swift
+++ b/Source/UIButton+AlamofireImage.swift
@@ -78,8 +78,8 @@ extension UIButton {
     
         - parameter URL:              The URL used for the image request.
         - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
-                                      image view will not change its image until the image request finishes. `nil` by
-                                      default.
+                                      background image will not change its image until the image request finishes. 
+                                      `nil` by default.
     */
     public func af_setBackgroundImageForState(state: UIControlState, URL: NSURL, placeHolderImage: UIImage? = nil) {
         af_setBackgroundImageForState(state, URLRequest: URLRequestWithURL(URL), placeholderImage: placeHolderImage)
@@ -93,8 +93,8 @@ extension UIButton {
     
         - parameter URLRequest:       The URL request.
         - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
-                                      image view will not change its image until the image request finishes. `nil` by
-                                      default.
+                                      background image will not change its image until the image request finishes.
+                                      `nil` by default.
         - parameter completion:       A closure to be executed when the image request finishes. The closure
                                       has no return value and takes three arguments: the original request,
                                       the response from the server and the result containing either the
@@ -160,8 +160,7 @@ extension UIButton {
     
         - parameter URL:              The URL used for the image request.
         - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
-                                      image view will not change its image until the image request finishes. `nil` by
-                                      default.
+                                      image will not change its image until the image request finishes. `nil` by default.
     */
     public func af_setImageForState(state: UIControlState, URL: NSURL, placeHolderImage: UIImage? = nil) {
         af_setImageForState(state, URLRequest: URLRequestWithURL(URL), placeholderImage: placeHolderImage)
@@ -175,8 +174,7 @@ extension UIButton {
      
         - parameter URLRequest:       The URL request.
         - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
-                                      image view will not change its image until the image request finishes. `nil` by
-                                      default.
+                                      image will not change its image until the image request finishes. `nil` by default.
         - parameter completion:       A closure to be executed when the image request finishes. The closure
                                       has no return value and takes three arguments: the original request,
                                       the response from the server and the result containing either the

--- a/Source/UIButton+AlamofireImage.swift
+++ b/Source/UIButton+AlamofireImage.swift
@@ -1,0 +1,348 @@
+
+// UIButton+AlamofireImage.swift
+//
+// Copyright (c) 2015 Alamofire Software Foundation (http://alamofire.org/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Alamofire
+import UIKit
+
+extension UIButton {
+    
+    // MARK: Private
+    
+    private struct AssociatedKeys {
+        static var BackgroundImageRequestReceiptKey = "af_UIButton.BackgroundImage"
+        static var ImageDownloaderKey = "af_UIButton.ImageDownloader"
+        static var ImageRequestReceiptKey = "af_UIButton.Image"
+        static var SharedImageDownloaderKey = "af_UIButton.SharedImageDownloader"
+    }
+    
+    // MARK: - Properties
+    
+    /// The instance image downloader used to download all images. If this property is `nil`, the `UIButton` will
+    /// fallback on the `af_sharedImageDownloader` for all downloads. The most common use case for needing to use a
+    /// custom instance image downloader is when images are behind different basic auth credentials.
+    public var af_imageDownloader: ImageDownloader? {
+        get {
+            return objc_getAssociatedObject(self, &AssociatedKeys.ImageDownloaderKey) as? ImageDownloader
+        }
+        
+        set(downloader) {
+            objc_setAssociatedObject(self, &AssociatedKeys.ImageDownloaderKey, downloader, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+    
+    /// The shared image downloader used to download all images. By default, this is the default `ImageDownloader`
+    /// instance backed with an `AutoPurgingImageCache` which automatically evicts images from the cache when the memory
+    /// capacity is reached or memory warning notifications occur. The shared image downloader is only used if the
+    /// `af_imageDownloader` is `nil`.
+    public class var af_sharedImageDownloader: ImageDownloader {
+        get {
+            if let downloader = objc_getAssociatedObject(self, &AssociatedKeys.SharedImageDownloaderKey) as? ImageDownloader {
+                return downloader
+            }
+        
+            return ImageDownloader.defaultInstance
+        }
+        
+        set(downloader) {
+            objc_setAssociatedObject(self, &AssociatedKeys.SharedImageDownloaderKey, downloader, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+    
+    // MARK: Image Download methods
+    
+    /**
+        Asynchronously downloads an image from the specified URL and sets it once the request is finished.
+    
+        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
+        set immediately, and then the remote image will be set once the image request is finished.
+    
+        - parameter URL:              The URL used for the image request.
+        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
+                                      image view will not change its image until the image request finishes. `nil` by
+                                      default.
+    */
+    public func af_setBackgroundImageForState(state: UIControlState, URL: NSURL, placeHolderImage: UIImage? = nil) {
+        af_setBackgroundImageForState(state, URLRequest: URLRequestWithURL(URL), placeholderImage: placeHolderImage)
+    }
+    
+    /**
+        Asynchronously downloads an image from the specified URL and sets it once the request is finished.
+    
+        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
+        set immediately, and then the remote image will be set once the image request is finished.
+    
+        - parameter URLRequest:       The URL request.
+        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
+                                      image view will not change its image until the image request finishes. `nil` by
+                                      default.
+        - parameter completion:       A closure to be executed when the image request finishes. The closure
+                                      has no return value and takes three arguments: the original request,
+                                      the response from the server and the result containing either the
+                                      image or the error that occurred. If the image was returned from the
+                                      image cache, the response will be `nil`.
+    */
+    public func af_setBackgroundImageForState(
+        state: UIControlState,
+        URLRequest: URLRequestConvertible,
+        placeholderImage: UIImage?,
+        completion: (Response<UIImage, NSError> -> Void)? = nil)
+    {
+        guard !isImageURLRequest(URLRequest, equalToActiveRequestURLForState: state) else { return }
+        
+        af_cancelBackgroundImageRequestForState(state)
+        
+        let imageDownloader = af_imageDownloader ?? UIButton.af_sharedImageDownloader
+        let imageCache = imageDownloader.imageCache
+        
+        if let image = imageCache?.imageForRequest(URLRequest.URLRequest, withAdditionalIdentifier: nil) {
+            let response = Response<UIImage, NSError>(
+                request: URLRequest.URLRequest,
+                response: nil,
+                data: nil,
+                result: .Success(image)
+            )
+            
+            completion?(response)
+            setBackgroundImage(image, forState: state)
+            
+            return
+        }
+        
+        // Set the placeholder since we're going to have to download
+        if let placeholderImage = placeholderImage { self.setBackgroundImage(placeholderImage, forState: state)  }
+        
+        // Download the image, then set the image with no transition because is not supported yet.
+        let requestReceipt = imageDownloader.downloadImage(
+            URLRequest: URLRequest,
+            completion: { [weak self] response in
+                guard let strongSelf = self else { return }
+                
+                completion?(response)
+                
+                guard strongSelf.isBackgroundImageURLRequest(response.request, equalToActiveRequestURLForState: state) else { return }
+                
+                if let image = response.result.value {
+                    strongSelf.setBackgroundImage(image, forState: state)
+                }
+                
+                strongSelf.setBackgroundImageRequestReceipt(nil, forState: state)
+            }
+        )
+        
+        setBackgroundImageRequestReceipt(requestReceipt, forState: state)
+    }
+
+    /**
+        Asynchronously downloads an image from the specified URL and sets it once the request is finished.
+    
+        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
+        set immediately, and then the remote image will be set once the image request is finished.
+    
+        - parameter URL:              The URL used for the image request.
+        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
+                                      image view will not change its image until the image request finishes. `nil` by
+                                      default.
+    */
+    public func af_setImageForState(state: UIControlState, URL: NSURL, placeHolderImage: UIImage? = nil) {
+        af_setImageForState(state, URLRequest: URLRequestWithURL(URL), placeholderImage: placeHolderImage)
+    }
+    
+    /**
+        Asynchronously downloads an image from the specified URL and sets it once the request is finished.
+     
+        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
+        set immediately, and then the remote image will be set once the image request is finished.
+     
+        - parameter URLRequest:       The URL request.
+        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
+                                      image view will not change its image until the image request finishes. `nil` by
+                                      default.
+        - parameter completion:       A closure to be executed when the image request finishes. The closure
+                                      has no return value and takes three arguments: the original request,
+                                      the response from the server and the result containing either the
+                                      image or the error that occurred. If the image was returned from the
+                                      image cache, the response will be `nil`.
+     */
+    public func af_setImageForState(
+        state: UIControlState,
+        URLRequest: URLRequestConvertible,
+        placeholderImage: UIImage?,
+        completion: (Response<UIImage, NSError> -> Void)? = nil)
+    {
+        guard !isImageURLRequest(URLRequest, equalToActiveRequestURLForState: state) else { return }
+        
+        af_cancelImageRequestForState(state)
+        
+        let imageDownloader = af_imageDownloader ?? UIButton.af_sharedImageDownloader
+        let imageCache = imageDownloader.imageCache
+        
+        if let image = imageCache?.imageForRequest(URLRequest.URLRequest, withAdditionalIdentifier: nil) {
+            let response = Response<UIImage, NSError>(
+                request: URLRequest.URLRequest,
+                response: nil,
+                data: nil,
+                result: .Success(image)
+            )
+            
+            completion?(response)
+            setImage(image, forState: state)
+            
+            return
+        }
+        
+        // Set the placeholder since we're going to have to download
+        if let placeholderImage = placeholderImage { self.setImage(placeholderImage, forState: state)  }
+        
+        // Download the image, then set the image with no transition because is not supported yet.
+        let requestReceipt = imageDownloader.downloadImage(
+            URLRequest: URLRequest,
+            completion: { [weak self] response in
+                guard let strongSelf = self else { return }
+                
+                completion?(response)
+                
+                guard strongSelf.isImageURLRequest(response.request, equalToActiveRequestURLForState: state) else { return }
+                
+                if let image = response.result.value {
+                    strongSelf.setImage(image, forState: state)
+                }
+                
+                strongSelf.setImageRequestReceipt(nil, forState: state)
+            }
+        )
+        
+        setImageRequestReceipt(requestReceipt, forState: state)
+    }
+    
+    /**
+        Returns the active request receipt for the background image
+        
+        - parameter state - The `UIControlState`
+    */
+    public func af_activeBackgroundImageRequestReceiptForState(state: UIControlState) -> RequestReceipt? {
+        if let backgroundImagesReceipts = backgroundImageReceiptsForState(state) {
+            return backgroundImagesReceipts[state.rawValue]
+        }
+        
+        return nil
+    }
+    
+    /**
+        Returns the active request receipt for the image
+     
+        - parameter state - The `UIControlState`
+     */
+    public func af_activeImageRequestReceiptForState(state: UIControlState) -> RequestReceipt? {
+        if let backgroundImagesReceipts = imageReceiptsForState(state) {
+            return backgroundImagesReceipts[state.rawValue]
+        }
+        
+        return nil
+    }
+    
+    /**
+        Cancels the active download request for the background image, if one exists.
+    */
+    public func af_cancelBackgroundImageRequestForState(state: UIControlState) {
+        guard let activeRequestReceipt = af_activeBackgroundImageRequestReceiptForState(state) else { return }
+        
+        let imageDownloader = af_imageDownloader ?? UIButton.af_sharedImageDownloader
+        imageDownloader.cancelRequestForRequestReceipt(activeRequestReceipt)
+        
+        setBackgroundImageRequestReceipt(nil, forState: state)
+    }
+    
+    /**
+        Cancels the active download request for the image, if one exists.
+    */
+    public func af_cancelImageRequestForState(state: UIControlState) {
+        guard let activeRequestReceipt = af_activeImageRequestReceiptForState(state) else { return }
+        
+        let imageDownloader = af_imageDownloader ?? UIButton.af_sharedImageDownloader
+        imageDownloader.cancelRequestForRequestReceipt(activeRequestReceipt)
+        
+        setImageRequestReceipt(nil, forState: state)
+    }
+    
+    // MARK: - Private methods
+    
+    private func isBackgroundImageURLRequest(
+        URLRequest: URLRequestConvertible?,
+        equalToActiveRequestURLForState state: UIControlState) -> Bool {
+            
+        if let
+            // Gets the current `RequestReceipt` for the state
+            activeRequestReceipt = af_activeBackgroundImageRequestReceiptForState(state),
+            currentRequest = activeRequestReceipt.request.task.originalRequest
+            where currentRequest.URLString == URLRequest?.URLRequest.URLString
+        {
+            return true
+        }
+        
+        return false
+    }
+
+    
+    private func isImageURLRequest(URLRequest: URLRequestConvertible?, equalToActiveRequestURLForState state: UIControlState) -> Bool {
+        if let
+            // Gets the current `RequestReceipt` for the state
+            activeRequestReceipt = af_activeImageRequestReceiptForState(state),
+            currentRequest = activeRequestReceipt.request.task.originalRequest
+            where currentRequest.URLString == URLRequest?.URLRequest.URLString
+        {
+            return true
+        }
+        
+        return false
+    }
+    
+    private func backgroundImageReceiptsForState(state: UIControlState) -> [UInt: RequestReceipt]? {
+        return objc_getAssociatedObject(self, &AssociatedKeys.BackgroundImageRequestReceiptKey) as? [UInt: RequestReceipt]
+    }
+    
+    private func imageReceiptsForState(state: UIControlState) -> [UInt: RequestReceipt]? {
+        return objc_getAssociatedObject(self, &AssociatedKeys.ImageRequestReceiptKey) as? [UInt: RequestReceipt]
+    }
+    
+    private func setBackgroundImageRequestReceipt(requestReceipt: RequestReceipt?, forState state: UIControlState) {
+        var backgroundImagesReceipts = backgroundImageReceiptsForState(state) ?? [:]
+        backgroundImagesReceipts[state.rawValue] = requestReceipt
+        objc_setAssociatedObject(self, &AssociatedKeys.BackgroundImageRequestReceiptKey, backgroundImagesReceipts, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+    
+    private func setImageRequestReceipt(requestReceipt: RequestReceipt?, forState state: UIControlState) {
+        var imagesReceipts = imageReceiptsForState(state) ?? [:]
+        imagesReceipts[state.rawValue] = requestReceipt
+        objc_setAssociatedObject(self, &AssociatedKeys.ImageRequestReceiptKey, imagesReceipts, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+    
+    private func URLRequestWithURL(URL: NSURL) -> NSURLRequest {
+        let mutableURLRequest = NSMutableURLRequest(URL: URL)
+        for mimeType in Request.acceptableImageContentTypes {
+            mutableURLRequest.addValue(mimeType, forHTTPHeaderField: "Accept")
+        }
+        
+        return mutableURLRequest
+    }
+    
+}

--- a/Tests/UIButtonTests.swift
+++ b/Tests/UIButtonTests.swift
@@ -1,0 +1,648 @@
+//
+// UIButtonTests.swift
+//
+// Copyright (c) 2015 Alamofire Software Foundation (http://alamofire.org/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import Alamofire
+@testable import AlamofireImage
+import XCTest
+import UIKit
+
+private class TestButton: UIButton {
+    var imageObserver: (Void -> Void)?
+    
+    required init(imageObserver: (Void -> Void)? = nil) {
+        self.imageObserver = imageObserver
+        super.init(frame: CGRectZero)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func setBackgroundImage(image: UIImage?, forState state: UIControlState) {
+        super.setBackgroundImage(image, forState: state)
+        imageObserver?()
+    }
+    
+    override func setImage(image: UIImage?, forState state: UIControlState) {
+        super.setImage(image, forState: state)
+        imageObserver?()
+    }
+}
+
+class UIButtonTests: BaseTestCase {
+
+    let URL = NSURL(string: "https://httpbin.org/image/jpeg")!
+    
+    // MARK: - Setup and Teardown
+    
+    override func setUp() {
+        super.setUp()
+        ImageDownloader.defaultURLCache().removeAllCachedResponses()
+        ImageDownloader.defaultInstance.imageCache?.removeAllImages()
+        UIButton.af_sharedImageDownloader = ImageDownloader.defaultInstance
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    // MARK: - Image Download
+    
+    func testThatBackgroundImageCanBeDownloadedFromURL() {
+        // Given
+        let expectation = expectationWithDescription("background image should download successfully")
+        var backgroundImageDownloadComplete = false
+        
+        let button = TestButton {
+            backgroundImageDownloadComplete = true
+            expectation.fulfill()
+        }
+        
+        // When
+        button.af_setBackgroundImageForState(.Normal, URL: URL)
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(backgroundImageDownloadComplete)
+    }
+    
+    func testThatBackgroundImageCanBeCancelledAndDownloadedFromURL () {
+        // Given
+        let expectation = expectationWithDescription("background image should cancel and download successfully")
+        let button = UIButton()
+        var result: Result<UIImage, NSError>?
+        
+        // When
+        button.af_setBackgroundImageForState(.Normal, URL: URL)
+        button.af_cancelBackgroundImageRequestForState(.Normal)
+        button.af_setBackgroundImageForState(
+            .Normal,
+            URLRequest: NSURLRequest(URL: URL),
+            placeholderImage: nil) { response in
+                result = response.result
+                expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertNotNil(result?.value)
+    }
+    
+    func testThatImageCanBeCancelledAndDownloadedFromURL () {
+        // Given
+        let expectation = expectationWithDescription("image should cancel and download successfully")
+        let button = UIButton()
+        var result: Result<UIImage, NSError>?
+        
+        // When
+        button.af_setImageForState(.Normal, URL: URL)
+        button.af_cancelImageRequestForState(.Normal)
+        button.af_setImageForState(
+            .Normal,
+            URLRequest: NSURLRequest(URL: URL),
+            placeholderImage: nil) { response in
+                result = response.result
+                expectation.fulfill()
+        }
+        
+        // Then
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        XCTAssertNotNil(result?.value)
+    }
+    
+    func testThatImageCanBeDownloadedFromURL() {
+        // Given
+        let expectation = expectationWithDescription("image should download successfully")
+        var imageDownloadComplete = false
+        
+        let button = TestButton {
+            imageDownloadComplete = true
+            expectation.fulfill()
+        }
+        
+        // When
+        button.af_setImageForState(.Normal, URL: URL)
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(imageDownloadComplete)
+    }
+
+    func testThatActiveBackgroundImageRequestReceiptIsNilAfterImageDownloadCompletes() {
+        // Given
+        let expectation = expectationWithDescription("background image should download successfully")
+        var backgroundImageDownloadComplete = false
+        
+        let button = TestButton {
+            backgroundImageDownloadComplete = true
+            expectation.fulfill()
+        }
+        
+        // When
+        button.af_setBackgroundImageForState(.Normal, URL: URL)
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(backgroundImageDownloadComplete)
+        XCTAssertNil(button.af_activeBackgroundImageRequestReceiptForState(.Normal))
+    }
+    
+    func testThatActiveImageRequestReceiptIsNilAfterImageDownloadCompletes() {
+        // Given
+        let expectation = expectationWithDescription("image should download successfully")
+        var imageDownloadComplete = false
+        
+        let button = TestButton {
+            imageDownloadComplete = true
+            expectation.fulfill()
+        }
+        
+        // When
+        button.af_setImageForState(.Normal, URL: URL)
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(imageDownloadComplete)
+        XCTAssertNil(button.af_activeImageRequestReceiptForState(.Normal))
+    }
+    
+    func testThatMultipleBackgroundImageRequestReceiptStates() {
+        // Given
+        let button = TestButton()
+        var _URL = URL
+        
+        // When
+        let expectation1 = expectationWithDescription("background image should download successfully")
+        var normalStateBackgroundImageDownloadComplete = false
+        button.af_setBackgroundImageForState(.Normal, URL: _URL)
+        button.imageObserver = {
+            normalStateBackgroundImageDownloadComplete = true
+            expectation1.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        let expectation2 = expectationWithDescription("background image should download successfully")
+        var selectedStateBackgroundImageDownloadComplete = false
+        _URL = NSURL(string: "https://httpbin.org/image/jpeg?random=\(random())")!
+        
+        button.af_setBackgroundImageForState(.Selected, URL: _URL)
+        button.imageObserver = {
+            selectedStateBackgroundImageDownloadComplete = true
+            expectation2.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        let expectation3 = expectationWithDescription("background image should download successfully")
+        var highlightedStateBackgroundImageDownloadComplete = false
+        _URL = NSURL(string: "https://httpbin.org/image/jpeg?random=\(random())")!
+        
+        button.af_setBackgroundImageForState(.Highlighted, URL: _URL)
+        button.imageObserver = {
+            highlightedStateBackgroundImageDownloadComplete = true
+            expectation3.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        let expectation4 = expectationWithDescription("background image should download successfully")
+        var disabledStateBackgroundImageDownloadComplete = false
+        _URL = NSURL(string: "https://httpbin.org/image/jpeg?random=\(random())")!
+        
+        button.af_setBackgroundImageForState(.Disabled, URL: _URL)
+        button.imageObserver = {
+            disabledStateBackgroundImageDownloadComplete = true
+            expectation4.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(normalStateBackgroundImageDownloadComplete)
+        XCTAssertNotNil(button.backgroundImageForState(.Normal))
+        
+        XCTAssertTrue(selectedStateBackgroundImageDownloadComplete)
+        XCTAssertNotNil(button.backgroundImageForState(.Selected))
+        
+        XCTAssertTrue(highlightedStateBackgroundImageDownloadComplete)
+        XCTAssertNotNil(button.backgroundImageForState(.Highlighted))
+        
+        XCTAssertTrue(disabledStateBackgroundImageDownloadComplete)
+        XCTAssertNotNil(button.backgroundImageForState(.Disabled))
+    }
+
+    func testThatMultipleImageRequestReceiptStates() {
+        // Given
+        let button = TestButton()
+        var _URL = URL
+        
+        // When
+        let expectation1 = expectationWithDescription("background image should download successfully")
+        var normalStateImageDownloadComplete = false
+        button.af_setImageForState(.Normal, URL: _URL)
+        button.imageObserver = {
+            normalStateImageDownloadComplete = true
+            expectation1.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        let expectation2 = expectationWithDescription("background image should download successfully")
+        var selectedStateImageDownloadComplete = false
+        _URL = NSURL(string: "https://httpbin.org/image/jpeg?random=\(random())")!
+        
+        button.af_setImageForState(.Selected, URL: _URL)
+        button.imageObserver = {
+            selectedStateImageDownloadComplete = true
+            expectation2.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        let expectation3 = expectationWithDescription("background image should download successfully")
+        var highlightedStateImageDownloadComplete = false
+        _URL = NSURL(string: "https://httpbin.org/image/jpeg?random=\(random())")!
+        
+        button.af_setImageForState(.Highlighted, URL: _URL)
+        button.imageObserver = {
+            highlightedStateImageDownloadComplete = true
+            expectation3.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        let expectation4 = expectationWithDescription("background image should download successfully")
+        var disabledStateImageDownloadComplete = false
+        _URL = NSURL(string: "https://httpbin.org/image/jpeg?random=\(random())")!
+        
+        button.af_setImageForState(.Disabled, URL: _URL)
+        button.imageObserver = {
+            disabledStateImageDownloadComplete = true
+            expectation4.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(normalStateImageDownloadComplete)
+        XCTAssertNotNil(button.imageForState(.Normal))
+        
+        XCTAssertTrue(selectedStateImageDownloadComplete)
+        XCTAssertNotNil(button.imageForState(.Selected))
+        
+        XCTAssertTrue(highlightedStateImageDownloadComplete)
+        XCTAssertNotNil(button.imageForState(.Highlighted))
+        
+        XCTAssertTrue(disabledStateImageDownloadComplete)
+        XCTAssertNotNil(button.imageForState(.Disabled))
+    }
+    
+    // MARK: - Image Downloaders
+    
+    func testThatInstanceImageDownloaderOverridesSharedImageDownloader() {
+        // Given
+        let expectation = expectationWithDescription("image should download successfully")
+        var imageDownloadComplete = false
+        
+        let button = TestButton {
+            imageDownloadComplete = true
+            expectation.fulfill()
+        }
+        
+        let configuration = NSURLSessionConfiguration.ephemeralSessionConfiguration()
+        let imageDownloader = ImageDownloader(configuration: configuration)
+        button.af_imageDownloader = imageDownloader
+        
+        // When
+        button.af_setImageForState(.Normal, URL: URL)
+        let activeRequestCount = imageDownloader.activeRequestCount
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(imageDownloadComplete)
+        XCTAssertNil(button.af_activeImageRequestReceiptForState(.Normal), "active request receipt should be nil after download completes")
+        XCTAssertEqual(activeRequestCount, 1, "active request count should be 1")
+    }
+    
+    // MARK: - Image Cache
+    
+    func testThatImageCanBeLoadedFromImageCache() {
+        // Given
+        let button = UIButton()
+        let downloader = ImageDownloader.defaultInstance
+        let download = URLRequest(.GET, URL.absoluteString)
+        let expectation = expectationWithDescription("image download should succeed")
+        
+        downloader.downloadImage(URLRequest: download) { _ in
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // When
+        button.af_setImageForState(.Normal, URL: URL)
+        button.af_cancelImageRequestForState(.Normal)
+        
+        // Then
+        XCTAssertNotNil(button.imageForState(.Normal), "button image should not be nil")
+    }
+    
+    func testThatSharedImageCacheCanBeReplaced() {
+        // Given
+        let imageDownloader = ImageDownloader()
+        
+        // When
+        let firstEqualityCheck = UIButton.af_sharedImageDownloader === imageDownloader
+        UIButton.af_sharedImageDownloader = imageDownloader
+        let secondEqualityCheck = UIButton.af_sharedImageDownloader === imageDownloader
+        
+        // Then
+        XCTAssertFalse(firstEqualityCheck, "first equality check should be false")
+        XCTAssertTrue(secondEqualityCheck, "second equality check should be true")
+    }
+    
+    // MARK: - Placeholder Images
+    
+    func testThatBackgroundPlaceholderImageIsDisplayedUntilImageIsDownloadedFromURL() {
+        // Given
+        let placeholderImage = imageForResource("pirate", withExtension: "jpg")
+        let expectation = expectationWithDescription("image should download successfully")
+        
+        var backgroundImageDownloadComplete = false
+        var finalBackgroundImageEqualsPlaceholderImage = false
+        
+        let button = TestButton ()
+        
+        // When
+        button.af_setBackgroundImageForState(.Normal, URL: URL, placeHolderImage: placeholderImage)
+        let initialImageEqualsPlaceholderImage = button.backgroundImageForState(.Normal) === placeholderImage
+        
+        button.imageObserver = {
+            backgroundImageDownloadComplete = true
+            finalBackgroundImageEqualsPlaceholderImage = button.backgroundImageForState(.Normal) === placeholderImage
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(backgroundImageDownloadComplete)
+        XCTAssertTrue(initialImageEqualsPlaceholderImage, "initial image should equal placeholder image")
+        XCTAssertFalse(finalBackgroundImageEqualsPlaceholderImage, "final image should not equal placeholder image")
+    }
+    
+    func testThatPlaceholderImageIsDisplayedUntilImageIsDownloadedFromURL() {
+        // Given
+        let placeholderImage = imageForResource("pirate", withExtension: "jpg")
+        let expectation = expectationWithDescription("image should download successfully")
+        
+        var imageDownloadComplete = false
+        var finalImageEqualsPlaceholderImage = false
+        
+        let button = TestButton ()
+        
+        // When
+        button.af_setImageForState(.Normal, URL: URL, placeHolderImage: placeholderImage)
+        let initialImageEqualsPlaceholderImage = button.imageForState(.Normal) === placeholderImage
+        
+        button.imageObserver = {
+            imageDownloadComplete = true
+            finalImageEqualsPlaceholderImage = button.imageForState(.Normal) === placeholderImage
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(imageDownloadComplete)
+        XCTAssertTrue(initialImageEqualsPlaceholderImage, "initial image should equal placeholder image")
+        XCTAssertFalse(finalImageEqualsPlaceholderImage, "final image should not equal placeholder image")
+    }
+    
+    func testThatBackgroundPlaceholderIsNeverDisplayedIfCachedImageIsAvailable() {
+        // Given
+        let placeholderImage = imageForResource("pirate", withExtension: "jpg")
+        let button = UIButton()
+        
+        let downloader = ImageDownloader.defaultInstance
+        let download = URLRequest(.GET, URL.absoluteString)
+        let expectation = expectationWithDescription("image download should succeed")
+        
+        downloader.downloadImage(URLRequest: download) { _ in
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // When
+        button.af_setBackgroundImageForState(.Normal, URL: URL, placeHolderImage: placeholderImage)
+        
+        // Then
+        XCTAssertNotNil(button.backgroundImageForState(.Normal), "button background image should not be nil")
+        XCTAssertFalse(button.backgroundImageForState(.Normal) === placeholderImage, "button background image should not equal placeholder image")
+    }
+    
+    func testThatImagePlaceholderIsNeverDisplayedIfCachedImageIsAvailable() {
+        // Given
+        let placeholderImage = imageForResource("pirate", withExtension: "jpg")
+        let button = UIButton()
+        
+        let downloader = ImageDownloader.defaultInstance
+        let download = URLRequest(.GET, URL.absoluteString)
+        let expectation = expectationWithDescription("image download should succeed")
+        
+        downloader.downloadImage(URLRequest: download) { _ in
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // When
+        button.af_setImageForState(.Normal, URL: URL, placeHolderImage: placeholderImage)
+        
+        // Then
+        XCTAssertNotNil(button.imageForState(.Normal), "button image should not be nil")
+        XCTAssertFalse(button.imageForState(.Normal) === placeholderImage, "button image should not equal placeholder image")
+    }
+    
+    // MARK: - Completion Handler
+    
+    func testThatCompletionHandlerIsCalledWhenBackgroundImageDownloadSucceeds() {
+        // Given
+        let button = UIButton()
+        
+        let URLRequest: NSURLRequest = {
+            let request = NSMutableURLRequest(URL: URL)
+            request.addValue("image/*", forHTTPHeaderField: "Accept")
+            return request
+        }()
+        
+        let expectation = expectationWithDescription("image download should succeed")
+        
+        var completionHandlerCalled = false
+        var result: Result<UIImage, NSError>?
+        
+        // When
+        button.af_setBackgroundImageForState(.Normal, URLRequest: URLRequest, placeholderImage: nil) { response in
+            completionHandlerCalled = true
+            result = response.result
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(completionHandlerCalled, "completion handler called should be true")
+        XCTAssertNotNil(button.backgroundImageForState(.Normal), "button background image should be not be nil")
+        XCTAssertTrue(result?.isSuccess ?? false, "result should be a success case")
+    }
+    
+    func testThatCompletionHandlerIsCalledWhenBackgroundImageDownloadFails() {
+        // Given
+        let button = UIButton()
+        let URLRequest = NSURLRequest(URL: NSURL(string: "really-bad-domain")!)
+        
+        let expectation = expectationWithDescription("image download should succeed")
+        
+        var completionHandlerCalled = false
+        var result: Result<UIImage, NSError>?
+        
+        // When
+        button.af_setBackgroundImageForState(.Normal, URLRequest: URLRequest, placeholderImage: nil) { response in
+            completionHandlerCalled = true
+            result = response.result
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(completionHandlerCalled, "completion handler called should be true")
+        XCTAssertNil(button.backgroundImageForState(.Normal), "button background image should be nil")
+        XCTAssertTrue(result?.isFailure ?? false, "result should be a failure case")
+    }
+
+    func testThatCompletionHandlerIsCalledWhenImageDownloadSucceeds() {
+        // Given
+        let button = UIButton()
+        
+        let URLRequest: NSURLRequest = {
+            let request = NSMutableURLRequest(URL: URL)
+            request.addValue("image/*", forHTTPHeaderField: "Accept")
+            return request
+        }()
+        
+        let expectation = expectationWithDescription("image download should succeed")
+        
+        var completionHandlerCalled = false
+        var result: Result<UIImage, NSError>?
+        
+        // When
+        button.af_setImageForState(.Normal, URLRequest: URLRequest, placeholderImage: nil) { response in
+            completionHandlerCalled = true
+            result = response.result
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(completionHandlerCalled, "completion handler called should be true")
+        XCTAssertNotNil(button.imageForState(.Normal), "button image should be not be nil")
+        XCTAssertTrue(result?.isSuccess ?? false, "result should be a success case")
+    }
+    
+    func testThatCompletionHandlerIsCalledWhenImageDownloadFails() {
+        // Given
+        let button = UIButton()
+        let URLRequest = NSURLRequest(URL: NSURL(string: "really-bad-domain")!)
+        
+        let expectation = expectationWithDescription("image download should succeed")
+        
+        var completionHandlerCalled = false
+        var result: Result<UIImage, NSError>?
+        
+        // When
+        button.af_setImageForState(.Normal, URLRequest: URLRequest, placeholderImage: nil) { response in
+            completionHandlerCalled = true
+            result = response.result
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(completionHandlerCalled, "completion handler called should be true")
+        XCTAssertNil(button.imageForState(.Normal), "button image should be nil")
+        XCTAssertTrue(result?.isFailure ?? false, "result should be a failure case")
+    }
+    
+    // MARK: - Redirects
+    
+    func testThatBackgroundImageBehindRedirectCanBeDownloaded() {
+        // Given
+        let redirectURLString = "https://httpbin.org/image/png"
+        let URL = NSURL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
+        
+        let expectation = expectationWithDescription("image should download successfully")
+        var backgroundImageDownloadComplete = false
+        
+        let button = TestButton {
+            backgroundImageDownloadComplete = true
+            expectation.fulfill()
+        }
+        
+        // When
+        button.af_setBackgroundImageForState(.Normal, URL: URL)
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(backgroundImageDownloadComplete, "image download complete should be true")
+        XCTAssertNotNil(button.backgroundImageForState(.Normal), "button background image should not be nil")
+    }
+    
+    func testThatImageBehindRedirectCanBeDownloaded() {
+        // Given
+        let redirectURLString = "https://httpbin.org/image/png"
+        let URL = NSURL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
+        
+        let expectation = expectationWithDescription("image should download successfully")
+        var imageDownloadComplete = false
+        
+        let button = TestButton {
+            imageDownloadComplete = true
+            expectation.fulfill()
+        }
+        
+        // When
+        button.af_setImageForState(.Normal, URL: URL)
+        waitForExpectationsWithTimeout(timeout, handler: nil)
+        
+        // Then
+        XCTAssertTrue(imageDownloadComplete, "image download complete should be true")
+        XCTAssertNotNil(button.imageForState(.Normal), "button image should not be nil")
+    }
+    
+}


### PR DESCRIPTION
I am using this library in some personals projects and I noticed about there is not support to set a remote image as a background or image, I ended with this solution for iOS that can help with the [#13](https://github.com/Alamofire/AlamofireImage/issues/13) . I hope it fits the requirements and guidelines of AlamofireImage.

Regards.