### PR TITLE
added application/octet-stream content type to allow lcr images

### DIFF
--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -43,7 +43,8 @@ extension Request {
         "image/bmp",
         "image/x-bmp",
         "image/x-xbitmap",
-        "image/x-win-bitmap"
+        "image/x-win-bitmap",
+        "application/octet-stream"
     ]
 
     /**

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -52,8 +52,8 @@ class RequestTestCase: BaseTestCase {
         let afterCount = Request.acceptableImageContentTypes.count
 
         // Then
-        XCTAssertEqual(beforeCount, 10, "before count should be 10")
-        XCTAssertEqual(afterCount, 12, "after count should be 12")
+        XCTAssertEqual(beforeCount, 11, "before count should be 11")
+        XCTAssertEqual(afterCount, 13, "after count should be 13")
     }
 
     // MARK: - Image Serialization Tests


### PR DESCRIPTION
I think this can help with the issue [#46] (https://github.com/Alamofire/AlamofireImage/issues/46), since the content type for the .lsr image after the conversion is 'application/octet-stream', the current behavior of the AFImage still working as expected if this type is added in the "acceptableImageContentTypes" enum.

Regards.