### PR TITLE
Add Carthage/Build to .gitignore to match AlamoFire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+
+# Carthage
+Carthage/Build


### PR DESCRIPTION
Currently, when `carthage build` is run that includes AlamoFireImage, a symlink is created by Carthage inside the repository. If using submodules for dependencies, this will dirty the AlamoFireImage submodule. Adding Carthage/Build to the .gitignore matches the .gitignore that [AlamoFire currently has](https://github.com/Alamofire/Alamofire/blob/master/.gitignore).

:beers: 