### PR TITLE
Fixed build warnings in Xcode 7.3 beta 2 for Swift 2.2

### DIFF
--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -523,7 +523,7 @@ public class ImageDownloader {
 
     func startRequest(request: Request) {
         request.resume()
-        ++activeRequestCount
+        activeRequestCount += 1
     }
 
     func enqueueRequest(request: Request) {

--- a/Tests/ImageDownloaderTests.swift
+++ b/Tests/ImageDownloaderTests.swift
@@ -192,7 +192,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         downloader.downloadImages(URLRequests: [download1, download2], filter: nil) { closureResponse in
             results.append(closureResponse.result)
 
-            ++completedDownloads
+            completedDownloads += 1
             if completedDownloads == 2 { expectation.fulfill() }
         }
 


### PR DESCRIPTION
Changed uses of `++` for `+= 1`.

Same thing as for https://github.com/Alamofire/Alamofire/pull/1030, nothing major changed here really, and mostly ran with the suggestions from Xcode.

I'm not sure if this needs to go on a `swift-2.2` branch for now, but I though I'd make this for now to try and help out.