### PR TITLE
Replaced superfluous API methods with default parameter values

### DIFF
--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -230,45 +230,19 @@ public class ImageDownloader {
     /**
         Creates a download request using the internal Alamofire `Manager` instance for the specified URL request.
     
-        If the same download request is already in the queue or currently being downloaded, the completion handler is
-        appended to the already existing request. Once the request completes, all completion handlers attached to the
-        request are executed in the order they were added.
-
-        - parameter URLRequest: The URL request.
-        - parameter completion: The closure called when the download request is complete.
-
-        - returns: The request receipt for the download request if available. `nil` if the image is stored in the image
-                   cache and the URL request cache policy allows the cache to be used.
-    */
-    public func downloadImage(
-        URLRequest URLRequest: URLRequestConvertible,
-        completion: CompletionHandler?)
-        -> RequestReceipt?
-    {
-        return downloadImage(
-            URLRequest: URLRequest,
-            receiptID: NSUUID().UUIDString,
-            filter: nil,
-            completion: completion
-        )
-    }
-
-    /**
-        Creates a download request using the internal Alamofire `Manager` instance for the specified URL request.
-
-        If the same download request is already in the queue or currently being downloaded, the filter and completion 
-        handler are appended to the already existing request. Once the request completes, all filters and completion 
+        If the same download request is already in the queue or currently being downloaded, the filter and completion
+        handler are appended to the already existing request. Once the request completes, all filters and completion
         handlers attached to the request are executed in the order they were added. Additionally, any filters attached
         to the request with the same identifiers are only executed once. The resulting image is then passed into each
         completion handler paired with the filter.
-
+    
         You should not attempt to directly cancel the `request` inside the request receipt since other callers may be
         relying on the completion of that request. Instead, you should call `cancelRequestForRequestReceipt` with the
         returned request receipt to allow the `ImageDownloader` to optimize the cancellation on behalf of all active
         callers.
 
         - parameter URLRequest: The URL request.
-        - parameter filter      The image filter to apply to the image after the download is complete.
+        - parameter filter      The image filter to apply to the image after the download is complete. Defaults to `nil`.
         - parameter completion: The closure called when the download request is complete.
 
         - returns: The request receipt for the download request if available. `nil` if the image is stored in the image
@@ -276,7 +250,7 @@ public class ImageDownloader {
     */
     public func downloadImage(
         URLRequest URLRequest: URLRequestConvertible,
-        filter: ImageFilter?,
+        filter: ImageFilter? = nil,
         completion: CompletionHandler?)
         -> RequestReceipt?
     {

--- a/Source/UIButton+AlamofireImage.swift
+++ b/Source/UIButton+AlamofireImage.swift
@@ -102,41 +102,52 @@ extension UIButton {
 
     /**
         Asynchronously downloads an image from the specified URL and sets it once the request is finished.
-
+    
         If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
         set immediately, and then the remote image will be set once the image request is finished.
-
-        - parameter URL:              The URL used for the image request.
-        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
-                                      image will not change its image until the image request finishes. `nil` by default.
+    
+        - parameter URL:                The URL used for your image request.
+        - parameter placeholderImage:   The image to be set initially until the image request finished. If `nil`, the
+                                        image will not change its image until the image request finishes.
+                                        Defaults to `nil`.
+        - parameter completion:         A closure to be executed when the image request finishes. The closure
+                                        has no return value and takes three arguments: the original request,
+                                        the response from the server and the result containing either the
+                                        image or the error that occurred. If the image was returned from the
+                                        image cache, the response will be `nil`. Defaults to `nil`.
     */
     public func af_setImageForState(
         state: UIControlState,
         URL: NSURL,
-        placeHolderImage: UIImage? = nil)
+        placeHolderImage: UIImage? = nil,
+        completion: (Response<UIImage, NSError> -> Void)? = nil)
     {
-        af_setImageForState(state, URLRequest: URLRequestWithURL(URL), placeholderImage: placeHolderImage)
+        af_setImageForState(state,
+            URLRequest: URLRequestWithURL(URL),
+            placeholderImage: placeHolderImage,
+            completion: completion)
     }
 
     /**
-        Asynchronously downloads an image from the specified URL and sets it once the request is finished.
+        Asynchronously downloads an image from the specified URL request and sets it once the request is finished.
 
         If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
         set immediately, and then the remote image will be set once the image request is finished.
 
-        - parameter URLRequest:       The URL request.
-        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
-                                      image will not change its image until the image request finishes. `nil` by default.
-        - parameter completion:       A closure to be executed when the image request finishes. The closure
-                                      has no return value and takes three arguments: the original request,
-                                      the response from the server and the result containing either the
-                                      image or the error that occurred. If the image was returned from the
-                                      image cache, the response will be `nil`.
+        - parameter URLRequest:         The URL request.
+        - parameter placeholderImage:   The image to be set initially until the image request finished. If `nil`, the
+                                        image will not change its image until the image request finishes.
+                                        Defaults to `nil`.
+        - parameter completion:         A closure to be executed when the image request finishes. The closure
+                                        has no return value and takes three arguments: the original request,
+                                        the response from the server and the result containing either the
+                                        image or the error that occurred. If the image was returned from the
+                                        image cache, the response will be `nil`. Defaults to `nil`.
     */
     public func af_setImageForState(
         state: UIControlState,
         URLRequest: URLRequestConvertible,
-        placeholderImage: UIImage?,
+        placeholderImage: UIImage? = nil,
         completion: (Response<UIImage, NSError> -> Void)? = nil)
     {
         guard !isImageURLRequest(URLRequest, equalToActiveRequestURLForState: state) else { return }
@@ -215,35 +226,42 @@ extension UIButton {
         If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
         set immediately, and then the remote image will be set once the image request is finished.
 
-        - parameter URL:              The URL used for the image request.
-        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
-                                      background image will not change its image until the image request finishes.
-                                      `nil` by default.
+        - parameter URL:                The URL used for the image request.
+        - parameter placeholderImage:   The image to be set initially until the image request finished. If `nil`, the
+                                        background image will not change its image until the image request finishes.
+                                        Defaults to `nil`.
     */
-    public func af_setBackgroundImageForState(state: UIControlState, URL: NSURL, placeHolderImage: UIImage? = nil) {
-        af_setBackgroundImageForState(state, URLRequest: URLRequestWithURL(URL), placeholderImage: placeHolderImage)
+    public func af_setBackgroundImageForState(state: UIControlState,
+        URL: NSURL,
+        placeHolderImage: UIImage? = nil,
+        completion: (Response<UIImage, NSError> -> Void)? = nil)
+    {
+        af_setBackgroundImageForState(state,
+            URLRequest: URLRequestWithURL(URL),
+            placeholderImage: placeHolderImage,
+            completion: completion)
     }
 
     /**
-        Asynchronously downloads an image from the specified URL and sets it once the request is finished.
+        Asynchronously downloads an image from the specified URL request and sets it once the request is finished.
 
         If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
         set immediately, and then the remote image will be set once the image request is finished.
 
-        - parameter URLRequest:       The URL request.
-        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
-                                      background image will not change its image until the image request finishes.
-                                      `nil` by default.
-        - parameter completion:       A closure to be executed when the image request finishes. The closure
-                                      has no return value and takes three arguments: the original request,
-                                      the response from the server and the result containing either the
-                                      image or the error that occurred. If the image was returned from the
-                                      image cache, the response will be `nil`.
+        - parameter URLRequest:         The URL request.
+        - parameter placeholderImage:   The image to be set initially until the image request finished. If `nil`, the
+                                        background image will not change its image until the image request finishes.
+                                        Defaults to `nil`.
+        - parameter completion:         A closure to be executed when the image request finishes. The closure
+                                        has no return value and takes three arguments: the original request,
+                                        the response from the server and the result containing either the
+                                        image or the error that occurred. If the image was returned from the
+                                        image cache, the response will be `nil`. Defaults to `nil`.
     */
     public func af_setBackgroundImageForState(
         state: UIControlState,
         URLRequest: URLRequestConvertible,
-        placeholderImage: UIImage?,
+        placeholderImage: UIImage? = nil,
         completion: (Response<UIImage, NSError> -> Void)? = nil)
     {
         guard !isImageURLRequest(URLRequest, equalToActiveRequestURLForState: state) else { return }

--- a/Source/UIImageView+AlamofireImage.swift
+++ b/Source/UIImageView+AlamofireImage.swift
@@ -165,115 +165,6 @@ extension UIImageView {
     // MARK: - Image Download
 
     /**
-        Asynchronously downloads an image from the specified URL and sets it once the request is finished.
-
-        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be 
-        set immediately, and then the remote image will be set once the image request is finished.
-
-        - parameter URL:              The URL used for the image request.
-        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the 
-                                      image view will not change its image until the image request finishes. `nil` by 
-                                      default.
-    */
-    public func af_setImageWithURL(URL: NSURL, placeholderImage: UIImage? = nil) {
-        af_setImageWithURLRequest(
-            URLRequestWithURL(URL),
-            placeholderImage: placeholderImage,
-            filter: nil,
-            imageTransition: .None,
-            completion: nil
-        )
-    }
-
-    /**
-        Asynchronously downloads an image from the specified URL, applies the specified image filter to the downloaded 
-        image and sets it once finished.
-
-        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
-        set immediately, and then the remote image will be set once the image request is finished.
-
-        - parameter URL:              The URL used for the image request.
-        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
-                                      image view will not change its image until the image request finishes. `nil` by 
-                                      default.
-        - parameter filter:           The image filter applied to the image after the image request is finished.
-    */
-    public func af_setImageWithURL(URL: NSURL, placeholderImage: UIImage? = nil, filter: ImageFilter) {
-        af_setImageWithURLRequest(
-            URLRequestWithURL(URL),
-            placeholderImage: placeholderImage,
-            filter: filter,
-            imageTransition: .None,
-            completion: nil
-        )
-    }
-
-    /**
-        Asynchronously downloads an image from the specified URL and sets it once the request is finished while 
-        executing the image transition.
-
-        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
-        set immediately, and then the remote image will be set once the image request is finished.
-
-        - parameter URL:                        The URL used for the image request.
-        - parameter placeholderImage:           The image to be set initially until the image request finished. If
-                                                `nil`, the image view will not change its image until the image
-                                                request finishes. `nil` by default.
-        - parameter imageTransition:            The image transition animation applied to the image when set.
-        - parameter runImageTransitionIfCached: Whether to run the image transition if the image is cached. Defaults
-                                                to `false`.
-    */
-    public func af_setImageWithURL(
-        URL: NSURL,
-        placeholderImage: UIImage? = nil,
-        imageTransition: ImageTransition,
-        runImageTransitionIfCached: Bool = false)
-    {
-        af_setImageWithURLRequest(
-            URLRequestWithURL(URL),
-            placeholderImage: placeholderImage,
-            filter: nil,
-            imageTransition: imageTransition,
-            runImageTransitionIfCached: runImageTransitionIfCached,
-            completion: nil
-        )
-    }
-
-    /**
-        Asynchronously downloads an image from the specified URL, applies the specified image filter to the downloaded
-        image and sets it once finished while executing the image transition.
-
-        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
-        set immediately, and then the remote image will be set once the image request is finished.
-
-        - parameter URL:                        The URL used for the image request.
-        - parameter placeholderImage:           The image to be set initially until the image request finished. If
-                                                `nil`, the image view will not change its image until the image
-                                                request finishes.
-        - parameter filter:                     The image filter applied to the image after the image request is
-                                                finished.
-        - parameter imageTransition:            The image transition animation applied to the image when set.
-        - parameter runImageTransitionIfCached: Whether to run the image transition if the image is cached. Defaults
-                                                to `false`.
-    */
-    public func af_setImageWithURL(
-        URL: NSURL,
-        placeholderImage: UIImage?,
-        filter: ImageFilter?,
-        imageTransition: ImageTransition,
-        runImageTransitionIfCached: Bool = false)
-    {
-        af_setImageWithURLRequest(
-            URLRequestWithURL(URL),
-            placeholderImage: placeholderImage,
-            filter: filter,
-            imageTransition: imageTransition,
-            runImageTransitionIfCached: runImageTransitionIfCached,
-            completion: nil
-        )
-    }
-
-    /**
         Asynchronously downloads an image from the specified URL, applies the specified image filter to the downloaded
         image and sets it once finished while executing the image transition.
 
@@ -289,25 +180,26 @@ extension UIImageView {
         - parameter URL:                        The URL used for the image request.
         - parameter placeholderImage:           The image to be set initially until the image request finished. If
                                                 `nil`, the image view will not change its image until the image
-                                                request finishes.
+                                                request finishes. Defaults to `nil`.
         - parameter filter:                     The image filter applied to the image after the image request is
-                                                finished.
-        - parameter imageTransition:            The image transition animation applied to the image when set.
+                                                finished. Defaults to `nil`.
+        - parameter imageTransition:            The image transition animation applied to the image when set. 
+                                                Defaults to `.None`.
         - parameter runImageTransitionIfCached: Whether to run the image transition if the image is cached. Defaults
                                                 to `false`.
         - parameter completion:                 A closure to be executed when the image request finishes. The closure
                                                 has no return value and takes three arguments: the original request,
                                                 the response from the server and the result containing either the
                                                 image or the error that occurred. If the image was returned from the
-                                                image cache, the response will be `nil`.
+                                                image cache, the response will be `nil`. Defaults to `nil`.
     */
     public func af_setImageWithURL(
         URL: NSURL,
-        placeholderImage: UIImage?,
-        filter: ImageFilter?,
-        imageTransition: ImageTransition,
+        placeholderImage: UIImage? = nil,
+        filter: ImageFilter? = nil,
+        imageTransition: ImageTransition = .None,
         runImageTransitionIfCached: Bool = false,
-        completion: (Response<UIImage, NSError> -> Void)?)
+        completion: (Response<UIImage, NSError> -> Void)? = nil)
     {
         af_setImageWithURLRequest(
             URLRequestWithURL(URL),
@@ -320,7 +212,7 @@ extension UIImageView {
     }
 
     /**
-        Asynchronously downloads an image from the specified URL, applies the specified image filter to the downloaded
+        Asynchronously downloads an image from the specified URL Request, applies the specified image filter to the downloaded
         image and sets it once finished while executing the image transition.
 
         If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
@@ -335,25 +227,26 @@ extension UIImageView {
         - parameter URLRequest:                 The URL request.
         - parameter placeholderImage:           The image to be set initially until the image request finished. If
                                                 `nil`, the image view will not change its image until the image
-                                                request finishes.
+                                                request finishes. Defaults to `nil`.
         - parameter filter:                     The image filter applied to the image after the image request is
-                                                finished.
+                                                finished. Defaults to `nil`.
         - parameter imageTransition:            The image transition animation applied to the image when set.
+                                                Defaults to `.None`.
         - parameter runImageTransitionIfCached: Whether to run the image transition if the image is cached. Defaults
                                                 to `false`.
         - parameter completion:                 A closure to be executed when the image request finishes. The closure
                                                 has no return value and takes three arguments: the original request,
                                                 the response from the server and the result containing either the
                                                 image or the error that occurred. If the image was returned from the
-                                                image cache, the response will be `nil`.
+                                                image cache, the response will be `nil`. Defaults to `nil`.
     */
     public func af_setImageWithURLRequest(
         URLRequest: URLRequestConvertible,
-        placeholderImage: UIImage?,
-        filter: ImageFilter?,
-        imageTransition: ImageTransition,
+        placeholderImage: UIImage? = nil,
+        filter: ImageFilter? = nil,
+        imageTransition: ImageTransition = .None,
         runImageTransitionIfCached: Bool = false,
-        completion: (Response<UIImage, NSError> -> Void)?)
+        completion: (Response<UIImage, NSError> -> Void)? = nil)
     {
         guard !isURLRequestURLEqualToActiveRequestURL(URLRequest) else { return }
 


### PR DESCRIPTION
This refactor passes all unit tests. This PR does not break any existing APIs and can be included in a minor or patch version update, rather than a major version release.