### PR TITLE
add "image/x-ms-bmp" as acceptable Content Type

### DIFF
--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -43,7 +43,8 @@ extension Request {
         "image/bmp",
         "image/x-bmp",
         "image/x-xbitmap",
-        "image/x-win-bitmap"
+        "image/x-win-bitmap",
+        "image/x-ms-bmp"
     ]
 
     /**


### PR DESCRIPTION
My request is failing due "image/x-ms-bmp" is not listed as acceptable Content Type, just adding "image/x-ms-bmp" fix the problem.