### PR TITLE
Xcode 8 beta 2 compatibility

### DIFF
--- a/AlamofireImage.xcodeproj/project.pbxproj
+++ b/AlamofireImage.xcodeproj/project.pbxproj
@@ -2456,7 +2456,7 @@
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alamofire.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AlamofireImage;
 				SDKROOT = macosx;
@@ -2563,7 +2563,7 @@
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alamofire.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AlamofireImage;
 				SDKROOT = macosx;
@@ -2590,7 +2590,7 @@
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.alamofire.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AlamofireImage;
 				SDKROOT = macosx;

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "e891699312a5215ad0da9f8322c5da949f90db35"
+github "Alamofire/Alamofire" "fcb4829a78d28e3491c6767cfb74e774871943b0"

--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -151,7 +151,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
         }()
 
         #if os(iOS) || os(tvOS)
-            NotificationCenter.default().addObserver(
+            NotificationCenter.default.addObserver(
                 self,
                 selector: #selector(AutoPurgingImageCache.removeAllImages),
                 name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning,
@@ -161,7 +161,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
     }
 
     deinit {
-        NotificationCenter.default().removeObserver(self)
+        NotificationCenter.default.removeObserver(self)
     }
 
     // MARK: Add Image to Cache

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -120,7 +120,7 @@ public class ImageDownloader {
         - returns: The default `NSURLSessionConfiguration` instance.
     */
     public class func defaultURLSessionConfiguration() -> URLSessionConfiguration {
-        let configuration = URLSessionConfiguration.default()
+        let configuration = URLSessionConfiguration.default
 
         configuration.httpAdditionalHeaders = Manager.defaultHTTPHeaders
         configuration.httpShouldSetCookies = true

--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -152,7 +152,7 @@ extension Request {
         #if os(iOS) || os(tvOS)
             return UIScreen.main().scale
         #elseif os(watchOS)
-            return WKInterfaceDevice.currentDevice().screenScale
+            return WKInterfaceDevice.current().screenScale
         #endif
     }
 
@@ -167,24 +167,24 @@ extension Request {
     */
     public class func imageResponseSerializer() -> ResponseSerializer<NSImage, NSError> {
         return ResponseSerializer { request, response, data, error in
-            guard error == nil else { return .Failure(error!) }
+            guard error == nil else { return .failure(error!) }
 
-            guard let validData = data where validData.length > 0 else {
-                return .Failure(Request.imageDataError())
+            guard let validData = data where validData.count > 0 else {
+                return .failure(Request.imageDataError())
             }
 
             guard Request.validateContentTypeForRequest(request, response: response) else {
-                return .Failure(Request.contentTypeValidationError())
+                return .failure(Request.contentTypeValidationError())
             }
 
             guard let bitmapImage = NSBitmapImageRep(data: validData) else {
-                return .Failure(Request.imageDataError())
+                return .failure(Request.imageDataError())
             }
 
             let image = NSImage(size: NSSize(width: bitmapImage.pixelsWide, height: bitmapImage.pixelsHigh))
             image.addRepresentation(bitmapImage)
 
-            return .Success(image)
+            return .success(image)
         }
     }
 

--- a/Tests/BaseTestCase.swift
+++ b/Tests/BaseTestCase.swift
@@ -36,7 +36,7 @@ class BaseTestCase : XCTestCase {
 
         manager = {
             let configuration: URLSessionConfiguration = {
-                let configuration = URLSessionConfiguration.ephemeral()
+                let configuration = URLSessionConfiguration.ephemeral
 
                 let defaultHeaders = Manager.sharedInstance.session.configuration.httpAdditionalHeaders
                 configuration.httpAdditionalHeaders = defaultHeaders

--- a/Tests/ImageCacheTests.swift
+++ b/Tests/ImageCacheTests.swift
@@ -198,7 +198,7 @@ class ImageCacheTestCase: BaseTestCase {
         cache.addImage(image, withIdentifier: identifier)
         let cachedImageExists = cache.imageWithIdentifier(identifier) != nil
 
-        NotificationCenter.default().post(
+        NotificationCenter.default.post(
             name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning,
             object: nil
         )

--- a/Tests/ImageDownloaderTests.swift
+++ b/Tests/ImageDownloaderTests.swift
@@ -32,7 +32,7 @@ private class ThreadCheckFilter: ImageFilter {
 
     var filter: (Image) -> Image {
         return { image in
-            self.calledOnMainQueue = Thread.isMainThread()
+            self.calledOnMainQueue = Thread.isMainThread
             return image
         }
     }
@@ -257,7 +257,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader: ImageDownloader = {
             let configuration: URLSessionConfiguration = {
-                let configuration = URLSessionConfiguration.default()
+                let configuration = URLSessionConfiguration.default
                 configuration.urlCache = nil
 
                 return configuration
@@ -429,7 +429,7 @@ class ImageDownloaderTestCase: BaseTestCase {
             progress: { _, _, _ in
                 if progressCalled == false {
                     progressCalled = true
-                    calledOnMainQueue = Thread.isMainThread()
+                    calledOnMainQueue = Thread.isMainThread
                     progressExpectation.fulfill()
                 }
             },
@@ -641,7 +641,7 @@ class ImageDownloaderTestCase: BaseTestCase {
 
         // When
         downloader.downloadImage(urlRequest: download) { _ in
-            calledOnMainQueue = Thread.isMainThread()
+            calledOnMainQueue = Thread.isMainThread
             expectation.fulfill()
         }
 

--- a/Tests/UIButtonTests.swift
+++ b/Tests/UIButtonTests.swift
@@ -327,7 +327,7 @@ class UIButtonTests: BaseTestCase {
             expectation.fulfill()
         }
 
-        let configuration = URLSessionConfiguration.ephemeral()
+        let configuration = URLSessionConfiguration.ephemeral
         let imageDownloader = ImageDownloader(configuration: configuration)
         button.af_imageDownloader = imageDownloader
 

--- a/Tests/UIImageViewTests.swift
+++ b/Tests/UIImageViewTests.swift
@@ -139,7 +139,7 @@ class UIImageViewTestCase: BaseTestCase {
             expectation.fulfill()
         }
 
-        let configuration = URLSessionConfiguration.ephemeral()
+        let configuration = URLSessionConfiguration.ephemeral
         let imageDownloader = ImageDownloader(configuration: configuration)
         imageView.af_imageDownloader = imageDownloader
 


### PR DESCRIPTION
There are some changes to Swift with Xcode 8 beta 2 from beta 1.

This PR

- updates the project so it compiles with beta 2
- updates tests so they build with beta 2
- increases macOS deployment target to 10.10 to the macOS target builds again (this is necessary because the new GCD API is only available on 10.10 or higher)
- updates Alamofire dependency

There are still some warnings about unused method results and the like that should be fixed down the road, but I think this is fine for now so we have a version that can be used for testing.

I also made sure all the tests are passing for all platforms. The travis build will fail because there is no Xcode 8 beta 2 available on travis yet.

If there is anything else that is needed for this to be merged, please let me know.