### PR TITLE
Updated Podspec to work with Alamofire 4 (Swift 3)

### DIFF
--- a/AlamofireImage.podspec
+++ b/AlamofireImage.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 
-  s.dependency 'Alamofire', '~> 3.3'
+  s.dependency 'Alamofire', '~> 4.0'
 end


### PR DESCRIPTION
Updated Podspec to require Alamofire 4 (Swift 3) so AlamofireImage is working alongside Alamofire when using the `swift3` branches on both of them.