### PR TITLE
Xcode 8 Beta 6 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.3
+osx_image: xcode8
 env:
   global:
   - LC_CTYPE=en_US.UTF-8
@@ -9,39 +9,22 @@ env:
   - OSX_FRAMEWORK_SCHEME="AlamofireImage OSX"
   - TVOS_FRAMEWORK_SCHEME="AlamofireImage tvOS"
   - WATCHOS_FRAMEWORK_SCHEME="AlamofireImage watchOS"
-  - IOS_SDK=iphonesimulator9.3
-  - OSX_SDK=macosx10.11
-  - TVOS_SDK=appletvsimulator9.2
-  - WATCHOS_SDK=watchsimulator2.2
+  - IOS_SDK=iphonesimulator10.0
+  - OSX_SDK=macosx10.12
+  - TVOS_SDK=appletvsimulator10.0
+  - WATCHOS_SDK=watchsimulator3.0
   - EXAMPLE_SCHEME="iOS Example"
   matrix:
-    - DESTINATION="OS=2.1,name=Apple Watch - 42mm" SCHEME="$WATCHOS_FRAMEWORK_SCHEME" SDK="$WATCHOS_SDK" RUN_TESTS="NO"  BUILD_EXAMPLE="NO" POD_LINT="YES"
-    - DESTINATION="OS=9.1,name=Apple TV 1080p"     SCHEME="$TVOS_FRAMEWORK_SCHEME"    SDK="$TVOS_SDK"    RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
-    - DESTINATION="arch=x86_64"                    SCHEME="$OSX_FRAMEWORK_SCHEME"     SDK="$OSX_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="NO" POD_LINT="NO"
-
-    - DESTINATION="OS=9.0,name=iPad 2"             SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-    - DESTINATION="OS=9.0,name=iPhone 6"           SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-    - DESTINATION="OS=9.0,name=iPhone 6 Plus"      SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-
-    - DESTINATION="OS=9.1,name=iPhone 6S"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-    - DESTINATION="OS=9.1,name=iPhone 6S Plus"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-
-    - DESTINATION="OS=9.2,name=iPhone 6S"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-    - DESTINATION="OS=9.2,name=iPhone 6S Plus"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-
-    - DESTINATION="OS=9.3,name=iPhone 6S"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-    - DESTINATION="OS=9.3,name=iPhone 6S Plus"     SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-
-    - DESTINATION="OS=8.1,name=iPad 2"             SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-    - DESTINATION="OS=8.2,name=iPhone 4S"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-    - DESTINATION="OS=8.3,name=iPhone 5"           SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-    - DESTINATION="OS=8.4,name=iPhone 5S"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
+    - DESTINATION="OS=10.0,name=iPhone 6S"         SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="YES"
+    - DESTINATION="OS=10.0,name=iPhone 5"          SCHEME="$IOS_FRAMEWORK_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
+    - DESTINATION="arch=x86_64"                    SCHEME="$OSX_FRAMEWORK_SCHEME"     SDK="$OSX_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
+    - DESTINATION="OS=10.0,name=Apple TV 1080p"    SCHEME="$TVOS_FRAMEWORK_SCHEME"    SDK="$TVOS_SDK"    RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
+    - DESTINATION="OS=3.0,name=Apple Watch - 42mm" SCHEME="$WATCHOS_FRAMEWORK_SCHEME" SDK="$WATCHOS_SDK" RUN_TESTS="NO"  BUILD_EXAMPLE="NO"  POD_LINT="NO"
 before_install:
-  - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
-  - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+  - gem install cocoapods --pre --no-rdoc --no-ri --no-document --quiet
 script:
   - set -o pipefail
-  - git submodule update --init --recursive
+  - git submodule update --init
   - xcodebuild -version
   - xcodebuild -showsdks
 
@@ -69,8 +52,9 @@ script:
       xcodebuild -workspace "$WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty -c; 
     fi
 
+  # Temporarily disabling pod lib lint check due to CocoaPods issue: https://github.com/CocoaPods/CocoaPods/issues/5661
   # Run `pod lib lint` if specified
-  - if [ $POD_LINT == "YES" ]; then
-      pod repo update master;
-      pod lib lint;
-    fi
+  # - if [ $POD_LINT == "YES" ]; then
+  #     pod repo update master;
+  #     pod lib lint;
+  #   fi

--- a/AlamofireImage.podspec
+++ b/AlamofireImage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'AlamofireImage'
-  s.version = '2.4.1'
+  s.version = '3.0.0-beta.1'
   s.license = 'MIT'
   s.summary = 'AlamofireImage is an image component library for Alamofire'
   s.homepage = 'https://github.com/Alamofire/AlamofireImage'
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 
-  s.dependency 'Alamofire', '~> 3.3'
+  s.dependency 'Alamofire', '4.0.0-beta.1'
 end

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "4f687613eaf2b10c1e54d5de54ed3da80be61508"
+github "Alamofire/Alamofire" "a6b3bb60b05a4a3e25c9c9a86fcf96f54fac6b12"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "a6b3bb60b05a4a3e25c9c9a86fcf96f54fac6b12"
+github "Alamofire/Alamofire" "7e60eb777c208036ce08d4aa8ab645ef71844b0d"

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -31,7 +31,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: - Application State Methods
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(
+        _ application: UIApplication,
+        willFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?)
+        -> Bool
+    {
         window = {
             let window = UIWindow(frame: UIScreen.main.bounds)
 

--- a/Example/Gravatar.swift
+++ b/Example/Gravatar.swift
@@ -26,7 +26,7 @@ import Foundation
 import UIKit
 
 private extension String  {
-    var md5_hash: String {
+    var md5Hash: String {
         let trimmedString = lowercased().trimmingCharacters(in: CharacterSet.whitespaces)
         let utf8String = trimmedString.cString(using: String.Encoding.utf8)!
         let stringLength = CC_LONG(trimmedString.lengthOfBytes(using: String.Encoding.utf8))
@@ -57,13 +57,13 @@ private protocol QueryItemConvertible {
 
 public struct Gravatar {
     public enum DefaultImage: String, QueryItemConvertible {
-        case HTTP404 = "404"
-        case MysteryMan = "mm"
-        case Identicon = "identicon"
-        case MonsterID = "monsterid"
-        case Wavatar = "wavatar"
-        case Retro = "retro"
-        case Blank = "blank"
+        case http404 = "404"
+        case mysteryMan = "mm"
+        case identicon = "identicon"
+        case monsterID = "monsterid"
+        case wavatar = "wavatar"
+        case retro = "retro"
+        case blank = "blank"
 
         var queryItem: URLQueryItem {
             return URLQueryItem(name: "d", value: rawValue)
@@ -71,10 +71,10 @@ public struct Gravatar {
     }
 
     public enum Rating: String, QueryItemConvertible {
-        case G = "g"
-        case PG = "pg"
-        case R = "r"
-        case X = "x"
+        case g = "g"
+        case pg = "pg"
+        case r = "r"
+        case x = "x"
 
         var queryItem: URLQueryItem {
             return URLQueryItem(name: "r", value: rawValue)
@@ -86,13 +86,13 @@ public struct Gravatar {
     public let defaultImage: DefaultImage
     public let rating: Rating
 
-    private static let baseURL = Foundation.URL(string: "https://secure.gravatar.com/avatar")!
+    private static let baseURL = URL(string: "https://secure.gravatar.com/avatar")!
 
     public init(
         emailAddress: String,
-        defaultImage: DefaultImage = .MysteryMan,
+        defaultImage: DefaultImage = .mysteryMan,
         forceDefault: Bool = false,
-        rating: Rating = .PG)
+        rating: Rating = .pg)
     {
         self.email = emailAddress
         self.defaultImage = defaultImage
@@ -100,8 +100,8 @@ public struct Gravatar {
         self.rating = rating
     }
 
-    public func url(size: CGFloat, scale: CGFloat = UIScreen.main.scale) -> Foundation.URL {
-        let url = Gravatar.baseURL.appendingPathComponent(email.md5_hash)
+    public func url(size: CGFloat, scale: CGFloat = UIScreen.main.scale) -> URL {
+        let url = Gravatar.baseURL.appendingPathComponent(email.md5Hash)
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
 
         var queryItems = [defaultImage.queryItem, rating.queryItem]

--- a/Example/ImageCell.swift
+++ b/Example/ImageCell.swift
@@ -28,7 +28,7 @@ import Foundation
 import UIKit
 
 class ImageCell : UICollectionViewCell {
-    class var ReuseIdentifier: String { return "org.alamofire.identifier.\(self.dynamicType)" }
+    class var ReuseIdentifier: String { return "org.alamofire.identifier.\(type(of: self))" }
     let imageView: UIImageView
 
     // MARK: - Initialization

--- a/Example/ImageCell.swift
+++ b/Example/ImageCell.swift
@@ -57,11 +57,11 @@ class ImageCell : UICollectionViewCell {
 
     // MARK: - Lifecycle Methods
 
-    func configureCellWithURLString(_ URLString: String, placeholderImage: UIImage) {
+    func configureCell(with URLString: String, placeholderImage: UIImage) {
         let size = imageView.frame.size
 
-        imageView.af_setImageWithURL(
-            URL(string: URLString)!,
+        imageView.af_setImage(
+            withURL: URL(string: URLString)!,
             placeholderImage: placeholderImage,
             filter: AspectScaledToFillSizeWithRoundedCornersFilter(size: size, radius: 20.0),
             imageTransition: .crossDissolve(0.2)

--- a/Example/ImageViewController.swift
+++ b/Example/ImageViewController.swift
@@ -53,8 +53,8 @@ class ImageViewController : UIViewController {
 
         let URL = gravatar.url(size: view.bounds.size.width)
 
-        imageView.af_setImageWithURL(
-            URL,
+        imageView.af_setImage(
+            withURL: URL,
             placeholderImage: nil,
             filter: CircleFilter(),
             imageTransition: .flipFromBottom(0.5)

--- a/Example/ImagesViewController.swift
+++ b/Example/ImagesViewController.swift
@@ -77,7 +77,7 @@ class ImagesViewController: UIViewController {
         collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     }
 
-    private func sizeForCollectionViewItem() -> CGSize {
+    fileprivate func sizeForCollectionViewItem() -> CGSize {
         let viewWidth = view.bounds.size.width
 
         var cellWidth = (viewWidth - 4 * 8) / 3.0

--- a/Example/ImagesViewController.swift
+++ b/Example/ImagesViewController.swift
@@ -54,7 +54,7 @@ class ImagesViewController: UIViewController {
         for _ in 1...1_000 {
             let gravatar = Gravatar(
                 emailAddress: UUID().uuidString,
-                defaultImage: Gravatar.DefaultImage.Identicon,
+                defaultImage: Gravatar.DefaultImage.identicon,
                 forceDefault: true
             )
 
@@ -101,9 +101,17 @@ extension ImagesViewController : UICollectionViewDataSource {
         _ collectionView: UICollectionView,
         cellForItemAt indexPath: IndexPath) -> UICollectionViewCell
     {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ImageCell.ReuseIdentifier, for: indexPath) as! ImageCell
+        let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: ImageCell.ReuseIdentifier,
+            for: indexPath
+        ) as! ImageCell
+
         let gravatar = gravatars[(indexPath as NSIndexPath).row]
-        cell.configureCellWithURLString(gravatar.url(size: sizeForCollectionViewItem().width).urlString, placeholderImage: placeholderImage)
+
+        cell.configureCell(
+            with: gravatar.url(size: sizeForCollectionViewItem().width).urlString,
+            placeholderImage: placeholderImage
+        )
 
         return cell
     }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ AlamofireImage is an image component library for Alamofire.
 ## Requirements
 
 - iOS 9.0+ / Mac OS X 10.11+ / tvOS 9.0+ / watchOS 2.0+
-- Xcode 8.0 beta 3+
+- Xcode 8.0 beta 6+
 
 ## Migration Guides
 

--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -247,14 +247,12 @@ public class AutoPurgingImageCache: ImageRequestCache {
     public func removeImage(withIdentifier identifier: String) -> Bool {
         var removed = false
 
-        let removeWork = DispatchWorkItem(flags: [DispatchWorkItemFlags.barrier]) {
+        synchronizationQueue.sync {
             if let cachedImage = self.cachedImages.removeValue(forKey: identifier) {
                 self.currentMemoryUsage -= cachedImage.totalBytes
                 removed = true
             }
         }
-
-        synchronizationQueue.async(execute: removeWork)
 
         return removed
     }

--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -124,17 +124,15 @@ public class AutoPurgingImageCache: ImageRequestCache {
 
     // MARK: Initialization
 
-    /**
-        Initialies the `AutoPurgingImageCache` instance with the given memory capacity and preferred memory usage
-        after purge limit.
-
-        Please note, the memory capacity must always be greater than or equal to the preferred memory usage after purge.
-
-        - parameter memoryCapacity:                 The total memory capacity of the cache in bytes. `100 MB` by default.
-        - parameter preferredMemoryUsageAfterPurge: The preferred memory usage after purge in bytes. `60 MB` by default.
-
-        - returns: The new `AutoPurgingImageCache` instance.
-    */
+    /// Initialies the `AutoPurgingImageCache` instance with the given memory capacity and preferred memory usage
+    /// after purge limit.
+    ///
+    /// Please note, the memory capacity must always be greater than or equal to the preferred memory usage after purge.
+    ///
+    /// - parameter memoryCapacity:                 The total memory capacity of the cache in bytes. `100 MB` by default.
+    /// - parameter preferredMemoryUsageAfterPurge: The preferred memory usage after purge in bytes. `60 MB` by default.
+    ///
+    /// - returns: The new `AutoPurgingImageCache` instance.
     public init(memoryCapacity: UInt64 = 100_000_000, preferredMemoryUsageAfterPurge: UInt64 = 60_000_000) {
         self.memoryCapacity = memoryCapacity
         self.preferredMemoryUsageAfterPurge = preferredMemoryUsageAfterPurge
@@ -168,24 +166,20 @@ public class AutoPurgingImageCache: ImageRequestCache {
 
     // MARK: Add Image to Cache
 
-    /**
-        Adds the image to the cache using an identifier created from the request and optional identifier.
-
-        - parameter image:      The image to add to the cache.
-        - parameter request:    The request used to generate the image's unique identifier.
-        - parameter identifier: The additional identifier to append to the image's unique identifier.
-    */
+    /// Adds the image to the cache using an identifier created from the request and optional identifier.
+    ///
+    /// - parameter image:      The image to add to the cache.
+    /// - parameter request:    The request used to generate the image's unique identifier.
+    /// - parameter identifier: The additional identifier to append to the image's unique identifier.
     public func add(_ image: Image, for request: URLRequest, withIdentifier identifier: String? = nil) {
         let requestIdentifier = imageCacheKey(for: request, withIdentifier: identifier)
         add(image, withIdentifier: requestIdentifier)
     }
 
-    /**
-        Adds the image to the cache with the given identifier.
-
-        - parameter image:      The image to add to the cache.
-        - parameter identifier: The identifier to use to uniquely identify the image.
-    */
+    /// Adds the image to the cache with the given identifier.
+    ///
+    /// - parameter image:      The image to add to the cache.
+    /// - parameter identifier: The identifier to use to uniquely identify the image.
     public func add(_ image: Image, withIdentifier identifier: String) {
         let cacheWork = DispatchWorkItem(flags: [DispatchWorkItemFlags.barrier]) {
             let cachedImage = CachedImage(image, identifier: identifier)
@@ -232,27 +226,23 @@ public class AutoPurgingImageCache: ImageRequestCache {
 
     // MARK: Remove Image from Cache
 
-    /**
-        Removes the image from the cache using an identifier created from the request and optional identifier.
-
-        - parameter request:    The request used to generate the image's unique identifier.
-        - parameter identifier: The additional identifier to append to the image's unique identifier.
-
-        - returns: `true` if the image was removed, `false` otherwise.
-    */
+    /// Removes the image from the cache using an identifier created from the request and optional identifier.
+    ///
+    /// - parameter request:    The request used to generate the image's unique identifier.
+    /// - parameter identifier: The additional identifier to append to the image's unique identifier.
+    ///
+    /// - returns: `true` if the image was removed, `false` otherwise.
     @discardableResult
     public func removeImage(for request: URLRequest, withIdentifier identifier: String?) -> Bool {
         let requestIdentifier = imageCacheKey(for: request, withIdentifier: identifier)
         return removeImage(withIdentifier: requestIdentifier)
     }
 
-    /**
-        Removes the image from the cache matching the given identifier.
-
-        - parameter identifier: The unique identifier for the image.
-
-        - returns: `true` if the image was removed, `false` otherwise.
-    */
+    /// Removes the image from the cache matching the given identifier.
+    ///
+    /// - parameter identifier: The unique identifier for the image.
+    ///
+    /// - returns: `true` if the image was removed, `false` otherwise.
     @discardableResult
     public func removeImage(withIdentifier identifier: String) -> Bool {
         var removed = false
@@ -269,11 +259,9 @@ public class AutoPurgingImageCache: ImageRequestCache {
         return removed
     }
 
-    /**
-        Removes all images stored in the cache.
-
-        - returns: `true` if images were removed from the cache, `false` otherwise.
-    */
+    /// Removes all images stored in the cache.
+    ///
+    /// - returns: `true` if images were removed from the cache, `false` otherwise.
     @discardableResult
     @objc public func removeAllImages() -> Bool {
         var removed = false
@@ -292,26 +280,22 @@ public class AutoPurgingImageCache: ImageRequestCache {
 
     // MARK: Fetch Image from Cache
 
-    /**
-        Returns the image from the cache associated with an identifier created from the request and optional identifier.
-
-        - parameter request:    The request used to generate the image's unique identifier.
-        - parameter identifier: The additional identifier to append to the image's unique identifier.
-
-        - returns: The image if it is stored in the cache, `nil` otherwise.
-    */
+    /// Returns the image from the cache associated with an identifier created from the request and optional identifier.
+    ///
+    /// - parameter request:    The request used to generate the image's unique identifier.
+    /// - parameter identifier: The additional identifier to append to the image's unique identifier.
+    ///
+    /// - returns: The image if it is stored in the cache, `nil` otherwise.
     public func image(for request: URLRequest, withIdentifier identifier: String? = nil) -> Image? {
         let requestIdentifier = imageCacheKey(for: request, withIdentifier: identifier)
         return image(withIdentifier: requestIdentifier)
     }
 
-    /**
-        Returns the image in the cache associated with the given identifier.
-
-        - parameter identifier: The unique identifier for the image.
-
-        - returns: The image if it is stored in the cache, `nil` otherwise.
-    */
+    /// Returns the image in the cache associated with the given identifier.
+    ///
+    /// - parameter identifier: The unique identifier for the image.
+    ///
+    /// - returns: The image if it is stored in the cache, `nil` otherwise.
     public func image(withIdentifier identifier: String) -> Image? {
         var image: Image?
 

--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -181,7 +181,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
     /// - parameter image:      The image to add to the cache.
     /// - parameter identifier: The identifier to use to uniquely identify the image.
     public func add(_ image: Image, withIdentifier identifier: String) {
-        let cacheWork = DispatchWorkItem(flags: [DispatchWorkItemFlags.barrier]) {
+        synchronizationQueue.async(flags: [.barrier]) {
             let cachedImage = CachedImage(image, identifier: identifier)
 
             if let previousCachedImage = self.cachedImages[identifier] {
@@ -192,9 +192,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
             self.currentMemoryUsage += cachedImage.totalBytes
         }
 
-        synchronizationQueue.async(execute: cacheWork)
-
-        let cleanupWork = DispatchWorkItem(flags: [DispatchWorkItemFlags.barrier]) {
+        synchronizationQueue.async(flags: [.barrier]) {
             if self.currentMemoryUsage > self.memoryCapacity {
                 let bytesToPurge = self.currentMemoryUsage - self.preferredMemoryUsageAfterPurge
 
@@ -221,7 +219,6 @@ public class AutoPurgingImageCache: ImageRequestCache {
                 self.currentMemoryUsage -= bytesPurged
             }
         }
-        synchronizationQueue.async(execute: cleanupWork)
     }
 
     // MARK: Remove Image from Cache

--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -50,7 +50,7 @@ public protocol ImageCache {
 }
 
 /// The `ImageRequestCache` protocol extends the `ImageCache` protocol by adding methods for adding, removing and
-/// fetching images from a cache given an `NSURLRequest` and additional identifier.
+/// fetching images from a cache given an `URLRequest` and additional identifier.
 public protocol ImageRequestCache: ImageCache {
     /// Adds the image to the cache using an identifier created from the request and identifier.
     func add(_ image: Image, for request: URLRequest, withIdentifier identifier: String?)
@@ -154,7 +154,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
             NotificationCenter.default.addObserver(
                 self,
                 selector: #selector(AutoPurgingImageCache.removeAllImages),
-                name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning,
+                name: Notification.Name.UIApplicationDidReceiveMemoryWarning,
                 object: nil
             )
         #endif

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -59,7 +59,7 @@ public class ImageDownloader {
     public typealias CompletionHandler = (Response<Image, NSError>) -> Void
 
     /// The progress handler closure called periodically during an image download.
-    public typealias ProgressHandler = (bytesRead: Int64, totalBytesRead: Int64, totalExpectedBytesToRead: Int64) -> Void
+    public typealias ProgressHandler = (_ bytesRead: Int64, _ totalBytesRead: Int64, _ totalExpectedBytesToRead: Int64) -> Void
 
     /**
         Defines the order prioritization of incoming download requests being inserted into the queue.
@@ -92,7 +92,7 @@ public class ImageDownloader {
     public private(set) var credential: URLCredential?
 
     /// The underlying Alamofire `Manager` instance used to handle all download requests.
-    public let sessionManager: Alamofire.Manager
+    public let sessionManager: SessionManager
 
     let downloadPrioritization: DownloadPrioritization
     let maximumActiveDownloads: Int
@@ -124,7 +124,7 @@ public class ImageDownloader {
     public class func defaultURLSessionConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.default
 
-        configuration.httpAdditionalHeaders = Manager.defaultHTTPHeaders
+        configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders
         configuration.httpShouldSetCookies = true
         configuration.httpShouldUsePipelining = false
 
@@ -168,7 +168,7 @@ public class ImageDownloader {
         maximumActiveDownloads: Int = 4,
         imageCache: ImageRequestCache? = AutoPurgingImageCache())
     {
-        self.sessionManager = Alamofire.Manager(configuration: configuration)
+        self.sessionManager = SessionManager(configuration: configuration)
         self.sessionManager.startRequestsImmediately = false
 
         self.downloadPrioritization = downloadPrioritization
@@ -177,10 +177,10 @@ public class ImageDownloader {
     }
 
     /**
-        Initializes the `ImageDownloader` instance with the given sesion manager, download prioritization, maximum
+        Initializes the `ImageDownloader` instance with the given session manager, download prioritization, maximum
         active download count and image cache.
 
-        - parameter sessionManager:         The Alamofire `Manager` instance to handle all download requests.
+        - parameter sessionManager:         The Alamofire `SessionManager` instance to handle all download requests.
         - parameter downloadPrioritization: The download prioritization of the download queue. `.FIFO` by default.
         - parameter maximumActiveDownloads: The maximum number of active downloads allowed at any given time.
         - parameter imageCache:             The image cache used to store all downloaded images in.
@@ -188,7 +188,7 @@ public class ImageDownloader {
         - returns: The new `ImageDownloader` instance.
     */
     public init(
-        sessionManager: Manager,
+        sessionManager: SessionManager,
         downloadPrioritization: DownloadPrioritization = .fifo,
         maximumActiveDownloads: Int = 4,
         imageCache: ImageRequestCache? = AutoPurgingImageCache())
@@ -316,13 +316,7 @@ public class ImageDownloader {
 
             if let progress = progress {
                 request.progress { bytesRead, totalBytesRead, totalExpectedBytesToRead in
-                    progressQueue.async {
-                        progress(
-                            bytesRead: bytesRead,
-                            totalBytesRead: totalBytesRead,
-                            totalExpectedBytesToRead: totalExpectedBytesToRead
-                        )
-                    }
+                    progressQueue.async { progress(bytesRead, totalBytesRead, totalExpectedBytesToRead) }
                 }
             }
 

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -114,9 +114,9 @@ public class ImageDownloader {
     /// The default instance of `ImageDownloader` initialized with default values.
     public static let `default` = ImageDownloader()
 
-    /// Creates a default `NSURLSessionConfiguration` with common usage parameter values.
+    /// Creates a default `URLSessionConfiguration` with common usage parameter values.
     ///
-    /// - returns: The default `NSURLSessionConfiguration` instance.
+    /// - returns: The default `URLSessionConfiguration` instance.
     public class func defaultURLSessionConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.default
 
@@ -133,9 +133,9 @@ public class ImageDownloader {
         return configuration
     }
 
-    /// Creates a default `NSURLCache` with common usage parameter values.
+    /// Creates a default `URLCache` with common usage parameter values.
     ///
-    /// - returns: The default `NSURLCache` instance.
+    /// - returns: The default `URLCache` instance.
     public class func defaultURLCache() -> URLCache {
         return URLCache(
             memoryCapacity: 20 * 1024 * 1024, // 20 MB

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -61,12 +61,10 @@ public class ImageDownloader {
     /// The progress handler closure called periodically during an image download.
     public typealias ProgressHandler = (_ bytesRead: Int64, _ totalBytesRead: Int64, _ totalExpectedBytesToRead: Int64) -> Void
 
-    /**
-        Defines the order prioritization of incoming download requests being inserted into the queue.
-
-        - FIFO: All incoming downloads are added to the back of the queue.
-        - LIFO: All incoming downloads are added to the front of the queue.
-    */
+    /// Defines the order prioritization of incoming download requests being inserted into the queue.
+    ///
+    /// - fifo: All incoming downloads are added to the back of the queue.
+    /// - lifo: All incoming downloads are added to the front of the queue.
     public enum DownloadPrioritization {
         case fifo, lifo
     }
@@ -116,11 +114,9 @@ public class ImageDownloader {
     /// The default instance of `ImageDownloader` initialized with default values.
     public static let `default` = ImageDownloader()
 
-    /**
-        Creates a default `NSURLSessionConfiguration` with common usage parameter values.
-
-        - returns: The default `NSURLSessionConfiguration` instance.
-    */
+    /// Creates a default `NSURLSessionConfiguration` with common usage parameter values.
+    ///
+    /// - returns: The default `NSURLSessionConfiguration` instance.
     public class func defaultURLSessionConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.default
 
@@ -137,11 +133,9 @@ public class ImageDownloader {
         return configuration
     }
 
-    /**
-        Creates a default `NSURLCache` with common usage parameter values.
-
-        - returns: The default `NSURLCache` instance.
-    */
+    /// Creates a default `NSURLCache` with common usage parameter values.
+    ///
+    /// - returns: The default `NSURLCache` instance.
     public class func defaultURLCache() -> URLCache {
         return URLCache(
             memoryCapacity: 20 * 1024 * 1024, // 20 MB
@@ -150,18 +144,16 @@ public class ImageDownloader {
         )
     }
 
-    /**
-        Initializes the `ImageDownloader` instance with the given configuration, download prioritization, maximum active
-        download count and image cache.
-
-        - parameter configuration:          The `NSURLSessionConfiguration` to use to create the underlying Alamofire
-                                            `Manager` instance.
-        - parameter downloadPrioritization: The download prioritization of the download queue. `.FIFO` by default.
-        - parameter maximumActiveDownloads: The maximum number of active downloads allowed at any given time.
-        - parameter imageCache:             The image cache used to store all downloaded images in.
-
-        - returns: The new `ImageDownloader` instance.
-    */
+    /// Initializes the `ImageDownloader` instance with the given configuration, download prioritization, maximum active
+    /// download count and image cache.
+    ///
+    /// - parameter configuration:          The `URLSessionConfiguration` to use to create the underlying Alamofire
+    ///                                     `SessionManager` instance.
+    /// - parameter downloadPrioritization: The download prioritization of the download queue. `.fifo` by default.
+    /// - parameter maximumActiveDownloads: The maximum number of active downloads allowed at any given time.
+    /// - parameter imageCache:             The image cache used to store all downloaded images in.
+    ///
+    /// - returns: The new `ImageDownloader` instance.
     public init(
         configuration: URLSessionConfiguration = ImageDownloader.defaultURLSessionConfiguration(),
         downloadPrioritization: DownloadPrioritization = .fifo,
@@ -176,17 +168,15 @@ public class ImageDownloader {
         self.imageCache = imageCache
     }
 
-    /**
-        Initializes the `ImageDownloader` instance with the given session manager, download prioritization, maximum
-        active download count and image cache.
-
-        - parameter sessionManager:         The Alamofire `SessionManager` instance to handle all download requests.
-        - parameter downloadPrioritization: The download prioritization of the download queue. `.FIFO` by default.
-        - parameter maximumActiveDownloads: The maximum number of active downloads allowed at any given time.
-        - parameter imageCache:             The image cache used to store all downloaded images in.
-
-        - returns: The new `ImageDownloader` instance.
-    */
+    /// Initializes the `ImageDownloader` instance with the given session manager, download prioritization, maximum
+    /// active download count and image cache.
+    ///
+    /// - parameter sessionManager:         The Alamofire `SessionManager` instance to handle all download requests.
+    /// - parameter downloadPrioritization: The download prioritization of the download queue. `.fifo` by default.
+    /// - parameter maximumActiveDownloads: The maximum number of active downloads allowed at any given time.
+    /// - parameter imageCache:             The image cache used to store all downloaded images in.
+    ///
+    /// - returns: The new `ImageDownloader` instance.
     public init(
         sessionManager: SessionManager,
         downloadPrioritization: DownloadPrioritization = .fifo,
@@ -203,13 +193,11 @@ public class ImageDownloader {
 
     // MARK: - Authentication
 
-    /**
-        Associates an HTTP Basic Auth credential with all future download requests.
-
-        - parameter user:        The user.
-        - parameter password:    The password.
-        - parameter persistence: The URL credential persistence. `.ForSession` by default.
-    */
+    /// Associates an HTTP Basic Auth credential with all future download requests.
+    ///
+    /// - parameter user:        The user.
+    /// - parameter password:    The password.
+    /// - parameter persistence: The URL credential persistence. `.forSession` by default.
     public func addAuthentication(
         user: String,
         password: String,
@@ -219,11 +207,9 @@ public class ImageDownloader {
         addAuthentication(usingCredential: credential)
     }
 
-    /**
-        Associates the specified credential with all future download requests.
-
-        - parameter credential: The credential.
-    */
+    /// Associates the specified credential with all future download requests.
+    ///
+    /// - parameter credential: The credential.
     public func addAuthentication(usingCredential credential: URLCredential) {
         synchronizationQueue.sync {
             self.credential = credential
@@ -232,33 +218,31 @@ public class ImageDownloader {
 
     // MARK: - Download
 
-    /**
-        Creates a download request using the internal Alamofire `Manager` instance for the specified URL request.
-
-        If the same download request is already in the queue or currently being downloaded, the filter and completion
-        handler are appended to the already existing request. Once the request completes, all filters and completion
-        handlers attached to the request are executed in the order they were added. Additionally, any filters attached
-        to the request with the same identifiers are only executed once. The resulting image is then passed into each
-        completion handler paired with the filter.
-
-        You should not attempt to directly cancel the `request` inside the request receipt since other callers may be
-        relying on the completion of that request. Instead, you should call `cancelRequestForRequestReceipt` with the
-        returned request receipt to allow the `ImageDownloader` to optimize the cancellation on behalf of all active
-        callers.
-
-        - parameter URLRequest:     The URL request.
-        - parameter receiptID:      The `identifier` for the `RequestReceipt` returned. Defaults to a new, randomly
-                                    generated UUID.
-        - parameter filter:         The image filter to apply to the image after the download is complete. Defaults
-                                    to `nil`.
-        - parameter progress:       The closure to be executed periodically during the lifecycle of the request.
-                                    Defaults to `nil`.
-        - parameter progressQueue:  The dispatch queue to call the progress closure on. Defaults to the main queue.
-        - parameter completion:     The closure called when the download request is complete. Defaults to `nil`.
-
-        - returns: The request receipt for the download request if available. `nil` if the image is stored in the image
-                   cache and the URL request cache policy allows the cache to be used.
-    */
+    /// Creates a download request using the internal Alamofire `SessionManager` instance for the specified URL request.
+    ///
+    /// If the same download request is already in the queue or currently being downloaded, the filter and completion
+    /// handler are appended to the already existing request. Once the request completes, all filters and completion
+    /// handlers attached to the request are executed in the order they were added. Additionally, any filters attached
+    /// to the request with the same identifiers are only executed once. The resulting image is then passed into each
+    /// completion handler paired with the filter.
+    ///
+    /// You should not attempt to directly cancel the `request` inside the request receipt since other callers may be
+    /// relying on the completion of that request. Instead, you should call `cancelRequestForRequestReceipt` with the
+    /// returned request receipt to allow the `ImageDownloader` to optimize the cancellation on behalf of all active
+    /// callers.
+    ///
+    /// - parameter urlRequest:     The URL request.
+    /// - parameter receiptID:      The `identifier` for the `RequestReceipt` returned. Defaults to a new, randomly
+    ///                             generated UUID.
+    /// - parameter filter:         The image filter to apply to the image after the download is complete. Defaults
+    ///                             to `nil`.
+    /// - parameter progress:       The closure to be executed periodically during the lifecycle of the request.
+    ///                             Defaults to `nil`.
+    /// - parameter progressQueue:  The dispatch queue to call the progress closure on. Defaults to the main queue.
+    /// - parameter completion:     The closure called when the download request is complete. Defaults to `nil`.
+    ///
+    /// - returns: The request receipt for the download request if available. `nil` if the image is stored in the image
+    ///            cache and the URL request cache policy allows the cache to be used.
     @discardableResult
     public func download(
         _ urlRequest: URLRequestConvertible,
@@ -393,31 +377,29 @@ public class ImageDownloader {
         return nil
     }
 
-    /**
-        Creates a download request using the internal Alamofire `Manager` instance for each specified URL request.
-
-        For each request, if the same download request is already in the queue or currently being downloaded, the
-        filter and completion handler are appended to the already existing request. Once the request completes, all
-        filters and completion handlers attached to the request are executed in the order they were added.
-        Additionally, any filters attached to the request with the same identifiers are only executed once. The
-        resulting image is then passed into each completion handler paired with the filter.
-
-        You should not attempt to directly cancel any of the `request`s inside the request receipts array since other
-        callers may be relying on the completion of that request. Instead, you should call
-        `cancelRequestForRequestReceipt` with the returned request receipt to allow the `ImageDownloader` to optimize
-        the cancellation on behalf of all active callers.
-
-        - parameter URLRequests:   The URL requests.
-        - parameter filter         The image filter to apply to the image after each download is complete.
-        - parameter progress:      The closure to be executed periodically during the lifecycle of the request. Defaults
-                                   to `nil`.
-        - parameter progressQueue: The dispatch queue to call the progress closure on. Defaults to the main queue.
-        - parameter completion:    The closure called when each download request is complete.
-
-        - returns: The request receipts for the download requests if available. If an image is stored in the image
-                   cache and the URL request cache policy allows the cache to be used, a receipt will not be returned
-                   for that request.
-    */
+    /// Creates a download request using the internal Alamofire `SessionManager` instance for each specified URL request.
+    ///
+    /// For each request, if the same download request is already in the queue or currently being downloaded, the
+    /// filter and completion handler are appended to the already existing request. Once the request completes, all
+    /// filters and completion handlers attached to the request are executed in the order they were added.
+    /// Additionally, any filters attached to the request with the same identifiers are only executed once. The
+    /// resulting image is then passed into each completion handler paired with the filter.
+    ///
+    /// You should not attempt to directly cancel any of the `request`s inside the request receipts array since other
+    /// callers may be relying on the completion of that request. Instead, you should call
+    /// `cancelRequestForRequestReceipt` with the returned request receipt to allow the `ImageDownloader` to optimize
+    /// the cancellation on behalf of all active callers.
+    ///
+    /// - parameter urlRequests:   The URL requests.
+    /// - parameter filter         The image filter to apply to the image after each download is complete.
+    /// - parameter progress:      The closure to be executed periodically during the lifecycle of the request. Defaults
+    ///                            to `nil`.
+    /// - parameter progressQueue: The dispatch queue to call the progress closure on. Defaults to the main queue.
+    /// - parameter completion:    The closure called when each download request is complete.
+    ///
+    /// - returns: The request receipts for the download requests if available. If an image is stored in the image
+    ///            cache and the URL request cache policy allows the cache to be used, a receipt will not be returned
+    ///            for that request.
     @discardableResult
     public func download(
         _ urlRequests: [URLRequestConvertible],
@@ -432,15 +414,13 @@ public class ImageDownloader {
         }
     }
 
-    /**
-        Cancels the request in the receipt by removing the response handler and cancelling the request if necessary.
-
-        If the request is pending in the queue, it will be cancelled if no other response handlers are registered with
-        the request. If the request is currently executing or is already completed, the response handler is removed and
-        will not be called.
-
-        - parameter requestReceipt: The request receipt to cancel.
-    */
+    /// Cancels the request in the receipt by removing the response handler and cancelling the request if necessary.
+    ///
+    /// If the request is pending in the queue, it will be cancelled if no other response handlers are registered with
+    /// the request. If the request is currently executing or is already completed, the response handler is removed and
+    /// will not be called.
+    ///
+    /// - parameter requestReceipt: The request receipt to cancel.
     public func cancelRequest(with requestReceipt: RequestReceipt) {
         synchronizationQueue.sync {
             let identifier = ImageDownloader.identifier(for: requestReceipt.request.request!)

--- a/Source/ImageFilter.swift
+++ b/Source/ImageFilter.swift
@@ -179,7 +179,7 @@ public struct ScaledToSizeFilter: ImageFilter, Sizable {
     /// The filter closure used to create the modified representation of the given image.
     public var filter: (Image) -> Image {
         return { image in
-            return image.af_imageScaledToSize(self.size)
+            return image.af_imageScaledTo(self.size)
         }
     }
 }
@@ -205,7 +205,7 @@ public struct AspectScaledToFitSizeFilter: ImageFilter, Sizable {
     /// The filter closure used to create the modified representation of the given image.
     public var filter: (Image) -> Image {
         return { image in
-            return image.af_imageAspectScaledToFitSize(self.size)
+            return image.af_imageAspectScaledToFit(self.size)
         }
     }
 }
@@ -232,7 +232,7 @@ public struct AspectScaledToFillSizeFilter: ImageFilter, Sizable {
     /// The filter closure used to create the modified representation of the given image.
     public var filter: (Image) -> Image {
         return { image in
-            return image.af_imageAspectScaledToFillSize(self.size)
+            return image.af_imageAspectScaledToFill(self.size)
         }
     }
 }

--- a/Source/ImageFilter.swift
+++ b/Source/ImageFilter.swift
@@ -171,7 +171,7 @@ public struct ScaledToSizeFilter: ImageFilter, Sizable {
     /// The filter closure used to create the modified representation of the given image.
     public var filter: (Image) -> Image {
         return { image in
-            return image.af_imageScaledTo(self.size)
+            return image.af_imageScaled(to: self.size)
         }
     }
 }
@@ -195,7 +195,7 @@ public struct AspectScaledToFitSizeFilter: ImageFilter, Sizable {
     /// The filter closure used to create the modified representation of the given image.
     public var filter: (Image) -> Image {
         return { image in
-            return image.af_imageAspectScaledToFit(self.size)
+            return image.af_imageAspectScaled(toFit: self.size)
         }
     }
 }
@@ -220,7 +220,7 @@ public struct AspectScaledToFillSizeFilter: ImageFilter, Sizable {
     /// The filter closure used to create the modified representation of the given image.
     public var filter: (Image) -> Image {
         return { image in
-            return image.af_imageAspectScaledToFill(self.size)
+            return image.af_imageAspectScaled(toFill: self.size)
         }
     }
 }
@@ -253,8 +253,8 @@ public struct RoundedCornersFilter: ImageFilter, Roundable {
     /// The filter closure used to create the modified representation of the given image.
     public var filter: (Image) -> Image {
         return { image in
-            return image.af_imageWithRoundedCornerRadius(
-                self.radius,
+            return image.af_imageRounded(
+                withCornerRadius: self.radius,
                 divideRadiusByImageScale: self.divideRadiusByImageScale
             )
         }
@@ -306,7 +306,7 @@ public struct BlurFilter: ImageFilter {
     public var filter: (Image) -> Image {
         return { image in
             let parameters: [String: Any] = ["inputRadius": self.blurRadius]
-            return image.af_imageWithAppliedCoreImageFilter("CIGaussianBlur", filterParameters: parameters) ?? image
+            return image.af_imageFiltered(withCoreImageFilter: "CIGaussianBlur", parameters: parameters) ?? image
         }
     }
 }

--- a/Source/ImageFilter.swift
+++ b/Source/ImageFilter.swift
@@ -43,7 +43,7 @@ public protocol ImageFilter {
 
 extension ImageFilter {
     /// The unique identifier for any `ImageFilter` type.
-    public var identifier: String { return "\(self.dynamicType)" }
+    public var identifier: String { return "\(type(of: self))" }
 }
 
 // MARK: - Sizable
@@ -60,7 +60,7 @@ extension ImageFilter where Self: Sizable {
         let width = Int64(round(size.width))
         let height = Int64(round(size.height))
 
-        return "\(self.dynamicType)-size:(\(width)x\(height))"
+        return "\(type(of: self))-size:(\(width)x\(height))"
     }
 }
 
@@ -76,7 +76,7 @@ extension ImageFilter where Self: Roundable {
     /// The unique idenitifier for an `ImageFilter` conforming to the `Roundable` protocol.
     public var identifier: String {
         let radius = Int64(round(self.radius))
-        return "\(self.dynamicType)-radius:(\(radius))"
+        return "\(type(of: self))-radius:(\(radius))"
     }
 }
 
@@ -98,7 +98,7 @@ public struct DynamicImageFilter: ImageFilter {
 
         - returns: The new `DynamicImageFilter` instance.
     */
-    public init(_ identifier: String, filter: (Image) -> Image) {
+    public init(_ identifier: String, filter: @escaping (Image) -> Image) {
         self.identifier = identifier
         self.filter = filter
     }
@@ -277,7 +277,7 @@ public struct RoundedCornersFilter: ImageFilter, Roundable {
     /// The unique idenitifier for an `ImageFilter` conforming to the `Roundable` protocol.
     public var identifier: String {
         let radius = Int64(round(self.radius))
-        return "\(self.dynamicType)-radius:(\(radius))-divided:(\(divideRadiusByImageScale))"
+        return "\(type(of: self))-radius:(\(radius))-divided:(\(divideRadiusByImageScale))"
     }
 }
 
@@ -323,7 +323,7 @@ public struct BlurFilter: ImageFilter {
     /// The filter closure used to create the modified representation of the given image.
     public var filter: (Image) -> Image {
         return { image in
-            let parameters = ["inputRadius": self.blurRadius]
+            let parameters: [String: Any] = ["inputRadius": self.blurRadius]
             return image.af_imageWithAppliedCoreImageFilter("CIGaussianBlur", filterParameters: parameters) ?? image
         }
     }

--- a/Source/ImageFilter.swift
+++ b/Source/ImageFilter.swift
@@ -90,14 +90,12 @@ public struct DynamicImageFilter: ImageFilter {
     /// A closure used to create an alternative representation of the given image.
     public let filter: (Image) -> Image
 
-    /**
-        Initializes the `DynamicImageFilter` instance with the specified identifier and filter closure.
-
-        - parameter identifier: The unique identifier of the filter.
-        - parameter filter:     A closure used to create an alternative representation of the given image.
-
-        - returns: The new `DynamicImageFilter` instance.
-    */
+    /// Initializes the `DynamicImageFilter` instance with the specified identifier and filter closure.
+    ///
+    /// - parameter identifier: The unique identifier of the filter.
+    /// - parameter filter:     A closure used to create an alternative representation of the given image.
+    ///
+    /// - returns: The new `DynamicImageFilter` instance.
     public init(_ identifier: String, filter: @escaping (Image) -> Image) {
         self.identifier = identifier
         self.filter = filter
@@ -133,24 +131,20 @@ public struct DynamicCompositeImageFilter: CompositeImageFilter {
     /// The image filters to apply to the image in sequential order.
     public let filters: [ImageFilter]
 
-    /**
-        Initializes the `DynamicCompositeImageFilter` instance with the given filters.
-
-        - parameter filters: The filters taking part in the composite image filter.
-
-        - returns: The new `DynamicCompositeImageFilter` instance.
-    */
+    /// Initializes the `DynamicCompositeImageFilter` instance with the given filters.
+    ///
+    /// - parameter filters: The filters taking part in the composite image filter.
+    ///
+    /// - returns: The new `DynamicCompositeImageFilter` instance.
     public init(_ filters: [ImageFilter]) {
         self.filters = filters
     }
 
-    /**
-        Initializes the `DynamicCompositeImageFilter` instance with the given filters.
-
-        - parameter filters: The filters taking part in the composite image filter.
-
-        - returns: The new `DynamicCompositeImageFilter` instance.
-    */
+    /// Initializes the `DynamicCompositeImageFilter` instance with the given filters.
+    ///
+    /// - parameter filters: The filters taking part in the composite image filter.
+    ///
+    /// - returns: The new `DynamicCompositeImageFilter` instance.
     public init(_ filters: ImageFilter...) {
         self.init(filters)
     }
@@ -165,13 +159,11 @@ public struct ScaledToSizeFilter: ImageFilter, Sizable {
     /// The size of the filter.
     public let size: CGSize
 
-    /**
-        Initializes the `ScaledToSizeFilter` instance with the given size.
-
-        - parameter size: The size.
-
-        - returns: The new `ScaledToSizeFilter` instance.
-    */
+    /// Initializes the `ScaledToSizeFilter` instance with the given size.
+    ///
+    /// - parameter size: The size.
+    ///
+    /// - returns: The new `ScaledToSizeFilter` instance.
     public init(size: CGSize) {
         self.size = size
     }
@@ -191,13 +183,11 @@ public struct AspectScaledToFitSizeFilter: ImageFilter, Sizable {
     /// The size of the filter.
     public let size: CGSize
 
-    /**
-        Initializes the `AspectScaledToFitSizeFilter` instance with the given size.
-
-        - parameter size: The size.
-
-        - returns: The new `AspectScaledToFitSizeFilter` instance.
-    */
+    /// Initializes the `AspectScaledToFitSizeFilter` instance with the given size.
+    ///
+    /// - parameter size: The size.
+    ///
+    /// - returns: The new `AspectScaledToFitSizeFilter` instance.
     public init(size: CGSize) {
         self.size = size
     }
@@ -218,13 +208,11 @@ public struct AspectScaledToFillSizeFilter: ImageFilter, Sizable {
     /// The size of the filter.
     public let size: CGSize
 
-    /**
-        Initializes the `AspectScaledToFillSizeFilter` instance with the given size.
-
-        - parameter size: The size.
-
-        - returns: The new `AspectScaledToFillSizeFilter` instance.
-    */
+    /// Initializes the `AspectScaledToFillSizeFilter` instance with the given size.
+    ///
+    /// - parameter size: The size.
+    ///
+    /// - returns: The new `AspectScaledToFillSizeFilter` instance.
     public init(size: CGSize) {
         self.size = size
     }
@@ -247,18 +235,16 @@ public struct RoundedCornersFilter: ImageFilter, Roundable {
     /// Whether to divide the radius by the image scale.
     public let divideRadiusByImageScale: Bool
 
-    /**
-        Initializes the `RoundedCornersFilter` instance with the given radius.
-
-        - parameter radius:                   The radius.
-        - parameter divideRadiusByImageScale: Whether to divide the radius by the image scale. Set to `true` when the
-                                              image has the same resolution for all screen scales such as @1x, @2x and
-                                              @3x (i.e. single image from web server). Set to `false` for images loaded
-                                              from an asset catalog with varying resolutions for each screen scale.
-                                              `false` by default.
-
-        - returns: The new `RoundedCornersFilter` instance.
-    */
+    /// Initializes the `RoundedCornersFilter` instance with the given radius.
+    ///
+    /// - parameter radius:                   The radius.
+    /// - parameter divideRadiusByImageScale: Whether to divide the radius by the image scale. Set to `true` when the
+    ///                                       image has the same resolution for all screen scales such as @1x, @2x and
+    ///                                       @3x (i.e. single image from web server). Set to `false` for images loaded
+    ///                                       from an asset catalog with varying resolutions for each screen scale.
+    ///                                       `false` by default.
+    ///
+    /// - returns: The new `RoundedCornersFilter` instance.
     public init(radius: CGFloat, divideRadiusByImageScale: Bool = false) {
         self.radius = radius
         self.divideRadiusByImageScale = divideRadiusByImageScale
@@ -285,11 +271,9 @@ public struct RoundedCornersFilter: ImageFilter, Roundable {
 
 /// Rounds the corners of an image into a circle.
 public struct CircleFilter: ImageFilter {
-    /**
-        Initializes the `CircleFilter` instance.
-
-        - returns: The new `CircleFilter` instance.
-    */
+    /// Initializes the `CircleFilter` instance.
+    ///
+    /// - returns: The new `CircleFilter` instance.
     public init() {}
 
     /// The filter closure used to create the modified representation of the given image.
@@ -309,13 +293,11 @@ public struct BlurFilter: ImageFilter {
     /// The blur radius of the filter.
     let blurRadius: UInt
 
-    /**
-        Initializes the `BlurFilter` instance with the given blur radius.
-
-        - parameter blurRadius: The blur radius.
-
-        - returns: The new `BlurFilter` instance.
-    */
+    /// Initializes the `BlurFilter` instance with the given blur radius.
+    ///
+    /// - parameter blurRadius: The blur radius.
+    ///
+    /// - returns: The new `BlurFilter` instance.
     public init(blurRadius: UInt = 10) {
         self.blurRadius = blurRadius
     }
@@ -335,19 +317,17 @@ public struct BlurFilter: ImageFilter {
 
 /// Scales an image to a specified size, then rounds the corners to the specified radius.
 public struct ScaledToSizeWithRoundedCornersFilter: CompositeImageFilter {
-    /**
-        Initializes the `ScaledToSizeWithRoundedCornersFilter` instance with the given size and radius.
-
-        - parameter size:                     The size.
-        - parameter radius:                   The radius.
-        - parameter divideRadiusByImageScale: Whether to divide the radius by the image scale. Set to `true` when the
-                                              image has the same resolution for all screen scales such as @1x, @2x and
-                                              @3x (i.e. single image from web server). Set to `false` for images loaded
-                                              from an asset catalog with varying resolutions for each screen scale.
-                                              `false` by default.
-
-        - returns: The new `ScaledToSizeWithRoundedCornersFilter` instance.
-    */
+    /// Initializes the `ScaledToSizeWithRoundedCornersFilter` instance with the given size and radius.
+    ///
+    /// - parameter size:                     The size.
+    /// - parameter radius:                   The radius.
+    /// - parameter divideRadiusByImageScale: Whether to divide the radius by the image scale. Set to `true` when the
+    ///                                       image has the same resolution for all screen scales such as @1x, @2x and
+    ///                                       @3x (i.e. single image from web server). Set to `false` for images loaded
+    ///                                       from an asset catalog with varying resolutions for each screen scale.
+    ///                                       `false` by default.
+    ///
+    /// - returns: The new `ScaledToSizeWithRoundedCornersFilter` instance.
     public init(size: CGSize, radius: CGFloat, divideRadiusByImageScale: Bool = false) {
         self.filters = [
             ScaledToSizeFilter(size: size),
@@ -364,19 +344,17 @@ public struct ScaledToSizeWithRoundedCornersFilter: CompositeImageFilter {
 /// Scales an image from the center while maintaining the aspect ratio to fit within a specified size, then rounds the
 /// corners to the specified radius.
 public struct AspectScaledToFillSizeWithRoundedCornersFilter: CompositeImageFilter {
-    /**
-        Initializes the `AspectScaledToFillSizeWithRoundedCornersFilter` instance with the given size and radius.
-
-        - parameter size:                     The size.
-        - parameter radius:                   The radius.
-        - parameter divideRadiusByImageScale: Whether to divide the radius by the image scale. Set to `true` when the
-                                              image has the same resolution for all screen scales such as @1x, @2x and
-                                              @3x (i.e. single image from web server). Set to `false` for images loaded
-                                              from an asset catalog with varying resolutions for each screen scale.
-                                              `false` by default.
-
-        - returns: The new `AspectScaledToFillSizeWithRoundedCornersFilter` instance.
-    */
+    /// Initializes the `AspectScaledToFillSizeWithRoundedCornersFilter` instance with the given size and radius.
+    ///
+    /// - parameter size:                     The size.
+    /// - parameter radius:                   The radius.
+    /// - parameter divideRadiusByImageScale: Whether to divide the radius by the image scale. Set to `true` when the
+    ///                                       image has the same resolution for all screen scales such as @1x, @2x and
+    ///                                       @3x (i.e. single image from web server). Set to `false` for images loaded
+    ///                                       from an asset catalog with varying resolutions for each screen scale.
+    ///                                       `false` by default.
+    ///
+    /// - returns: The new `AspectScaledToFillSizeWithRoundedCornersFilter` instance.
     public init(size: CGSize, radius: CGFloat, divideRadiusByImageScale: Bool = false) {
         self.filters = [
             AspectScaledToFillSizeFilter(size: size),
@@ -392,13 +370,11 @@ public struct AspectScaledToFillSizeWithRoundedCornersFilter: CompositeImageFilt
 
 /// Scales an image to a specified size, then rounds the corners into a circle.
 public struct ScaledToSizeCircleFilter: CompositeImageFilter {
-    /**
-        Initializes the `ScaledToSizeCircleFilter` instance with the given size.
-
-        - parameter size: The size.
-
-        - returns: The new `ScaledToSizeCircleFilter` instance.
-    */
+    /// Initializes the `ScaledToSizeCircleFilter` instance with the given size.
+    ///
+    /// - parameter size: The size.
+    ///
+    /// - returns: The new `ScaledToSizeCircleFilter` instance.
     public init(size: CGSize) {
         self.filters = [ScaledToSizeFilter(size: size), CircleFilter()]
     }
@@ -412,13 +388,11 @@ public struct ScaledToSizeCircleFilter: CompositeImageFilter {
 /// Scales an image from the center while maintaining the aspect ratio to fit within a specified size, then rounds the
 /// corners into a circle.
 public struct AspectScaledToFillSizeCircleFilter: CompositeImageFilter {
-    /**
-        Initializes the `AspectScaledToFillSizeCircleFilter` instance with the given size.
-
-        - parameter size: The size.
-
-        - returns: The new `AspectScaledToFillSizeCircleFilter` instance.
-    */
+    /// Initializes the `AspectScaledToFillSizeCircleFilter` instance with the given size.
+    ///
+    /// - parameter size: The size.
+    ///
+    /// - returns: The new `AspectScaledToFillSizeCircleFilter` instance.
     public init(size: CGSize) {
         self.filters = [AspectScaledToFillSizeFilter(size: size), CircleFilter()]
     }

--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -90,12 +90,12 @@ extension Request {
                 return .failure(Request.imageDataError())
             }
 
-            guard Request.validateContentType(forRequest: request, response: response) else {
+            guard Request.validateContentType(for: request, response: response) else {
                 return .failure(Request.contentTypeValidationError())
             }
 
             do {
-                let image = try Request.imageFromResponseData(validData, imageScale: imageScale)
+                let image = try Request.image(from: validData, withImageScale: imageScale)
                 if inflateResponseImage { image.af_inflate() }
 
                 return .success(image)
@@ -142,8 +142,8 @@ extension Request {
         )
     }
 
-    private class func imageFromResponseData(_ data: Data, imageScale: CGFloat) throws -> UIImage {
-        if let image = UIImage.af_threadSafeImageWithData(data, scale: imageScale) {
+    private class func image(from data: Data, withImageScale imageScale: CGFloat) throws -> UIImage {
+        if let image = UIImage.af_threadSafeImage(with: data, scale: imageScale) {
             return image
         }
 
@@ -175,7 +175,7 @@ extension Request {
                 return .failure(Request.imageDataError())
             }
 
-            guard Request.validateContentType(forRequest: request, response: response) else {
+            guard Request.validateContentType(for: request, response: response) else {
                 return .failure(Request.contentTypeValidationError())
             }
 
@@ -212,11 +212,7 @@ extension Request {
 
     // MARK: - Private - Shared Helper Methods
 
-    private class func validateContentType(
-        forRequest request: URLRequest?,
-        response:HTTPURLResponse?)
-        -> Bool
-    {
+    private class func validateContentType(for request: URLRequest?, response: HTTPURLResponse?) -> Bool {
         if let url = request?.url, url.isFileURL {
             return true
         }

--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -130,7 +130,7 @@ extension Request {
     public func responseImage(
         imageScale: CGFloat = Request.imageScale,
         inflateResponseImage: Bool = true,
-        completionHandler: (Response<Image, NSError>) -> Void)
+        completionHandler: @escaping (Response<Image, NSError>) -> Void)
         -> Self
     {
         return response(
@@ -201,7 +201,7 @@ extension Request {
         - returns: The request.
     */
     @discardableResult
-    public func responseImage(completionHandler: (Response<Image, NSError>) -> Void) -> Self {
+    public func responseImage(completionHandler: @escaping (Response<Image, NSError>) -> Void) -> Self {
         return response(
             responseSerializer: Request.imageResponseSerializer(),
             completionHandler: completionHandler

--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -49,11 +49,9 @@ extension Request {
         "image/x-win-bitmap"
     ]
 
-    /**
-        Adds the content types specified to the list of acceptable images content types for validation.
-
-        - parameter contentTypes: The additional content types.
-    */
+    /// Adds the content types specified to the list of acceptable images content types for validation.
+    ///
+    /// - parameter contentTypes: The additional content types.
     public class func addAcceptableImageContentTypes(_ contentTypes: Set<String>) {
         Request.acceptableImageContentTypes.formUnion(contentTypes)
     }
@@ -62,22 +60,20 @@ extension Request {
 
 #if os(iOS) || os(tvOS) || os(watchOS)
 
-    /**
-        Creates a response serializer that returns an image initialized from the response data using the specified
-        image options.
-
-        - parameter imageScale:           The scale factor used when interpreting the image data to construct
-                                          `responseImage`. Specifying a scale factor of 1.0 results in an image whose
-                                          size matches the pixel-based dimensions of the image. Applying a different
-                                          scale factor changes the size of the image as reported by the size property.
-                                          `Screen.scale` by default.
-        - parameter inflateResponseImage: Whether to automatically inflate response image data for compressed formats
-                                          (such as PNG or JPEG). Enabling this can significantly improve drawing
-                                          performance as it allows a bitmap representation to be constructed in the
-                                          background rather than on the main thread. `true` by default.
-
-        - returns: An image response serializer.
-    */
+    /// Creates a response serializer that returns an image initialized from the response data using the specified
+    /// image options.
+    ///
+    /// - parameter imageScale:           The scale factor used when interpreting the image data to construct
+    ///                                   `responseImage`. Specifying a scale factor of 1.0 results in an image whose
+    ///                                   size matches the pixel-based dimensions of the image. Applying a different
+    ///                                   scale factor changes the size of the image as reported by the size property.
+    ///                                   `Screen.scale` by default.
+    /// - parameter inflateResponseImage: Whether to automatically inflate response image data for compressed formats
+    ///                                   (such as PNG or JPEG). Enabling this can significantly improve drawing
+    ///                                   performance as it allows a bitmap representation to be constructed in the
+    ///                                   background rather than on the main thread. `true` by default.
+    ///
+    /// - returns: An image response serializer.
     public class func imageResponseSerializer(
         imageScale: CGFloat = Request.imageScale,
         inflateResponseImage: Bool = true)
@@ -105,27 +101,25 @@ extension Request {
         }
     }
 
-    /**
-        Adds a handler to be called once the request has finished.
-
-        - parameter imageScale:           The scale factor used when interpreting the image data to construct
-                                          `responseImage`. Specifying a scale factor of 1.0 results in an image whose
-                                          size matches the pixel-based dimensions of the image. Applying a different
-                                          scale factor changes the size of the image as reported by the size property.
-                                          This is set to the value of scale of the main screen by default, which
-                                          automatically scales images for retina displays, for instance.
-                                          `Screen.scale` by default.
-        - parameter inflateResponseImage: Whether to automatically inflate response image data for compressed formats
-                                          (such as PNG or JPEG). Enabling this can significantly improve drawing
-                                          performance as it allows a bitmap representation to be constructed in the
-                                          background rather than on the main thread. `true` by default.
-        - parameter completionHandler:    A closure to be executed once the request has finished. The closure takes 4
-                                          arguments: the URL request, the URL response, if one was received, the image,
-                                          if one could be created from the URL response and data, and any error produced
-                                          while creating the image.
-
-        - returns: The request.
-    */
+    /// Adds a handler to be called once the request has finished.
+    ///
+    /// - parameter imageScale:           The scale factor used when interpreting the image data to construct
+    ///                                   `responseImage`. Specifying a scale factor of 1.0 results in an image whose
+    ///                                   size matches the pixel-based dimensions of the image. Applying a different
+    ///                                   scale factor changes the size of the image as reported by the size property.
+    ///                                   This is set to the value of scale of the main screen by default, which
+    ///                                   automatically scales images for retina displays, for instance.
+    ///                                   `Screen.scale` by default.
+    /// - parameter inflateResponseImage: Whether to automatically inflate response image data for compressed formats
+    ///                                   (such as PNG or JPEG). Enabling this can significantly improve drawing
+    ///                                   performance as it allows a bitmap representation to be constructed in the
+    ///                                   background rather than on the main thread. `true` by default.
+    /// - parameter completionHandler:    A closure to be executed once the request has finished. The closure takes 4
+    ///                                   arguments: the URL request, the URL response, if one was received, the image,
+    ///                                   if one could be created from the URL response and data, and any error produced
+    ///                                   while creating the image.
+    ///
+    /// - returns: The request.
     @discardableResult
     public func responseImage(
         imageScale: CGFloat = Request.imageScale,
@@ -162,11 +156,9 @@ extension Request {
 
     // MARK: - OSX
 
-    /**
-        Creates a response serializer that returns an image initialized from the response data.
-
-        - returns: An image response serializer.
-    */
+    /// Creates a response serializer that returns an image initialized from the response data.
+    ///
+    /// - returns: An image response serializer.
     public class func imageResponseSerializer() -> ResponseSerializer<NSImage, NSError> {
         return ResponseSerializer { request, response, data, error in
             guard error == nil else { return .failure(error!) }
@@ -190,16 +182,14 @@ extension Request {
         }
     }
 
-    /**
-        Adds a handler to be called once the request has finished.
-
-        - parameter completionHandler: A closure to be executed once the request has finished. The closure takes 4
-                                       arguments: the URL request, the URL response, if one was received, the image, if
-                                       one could be created from the URL response and data, and any error produced while
-                                       creating the image.
-
-        - returns: The request.
-    */
+    /// Adds a handler to be called once the request has finished.
+    ///
+    /// - parameter completionHandler: A closure to be executed once the request has finished. The closure takes 4
+    ///                                arguments: the URL request, the URL response, if one was received, the image, if
+    ///                                one could be created from the URL response and data, and any error produced while
+    ///                                creating the image.
+    ///
+    /// - returns: The request.
     @discardableResult
     public func responseImage(completionHandler: @escaping (Response<Image, NSError>) -> Void) -> Self {
         return response(

--- a/Source/UIButton+AlamofireImage.swift
+++ b/Source/UIButton+AlamofireImage.swift
@@ -31,10 +31,10 @@ extension UIButton {
     // MARK: - Private - AssociatedKeys
 
     private struct AssociatedKey {
-        static var ImageDownloader = "af_UIButton.ImageDownloader"
-        static var SharedImageDownloader = "af_UIButton.SharedImageDownloader"
-        static var ImageReceipts = "af_UIButton.ImageReceipts"
-        static var BackgroundImageReceipts = "af_UIButton.BackgroundImageReceipts"
+        static var imageDownloader = "af_UIButton.ImageDownloader"
+        static var sharedImageDownloader = "af_UIButton.SharedImageDownloader"
+        static var imageReceipts = "af_UIButton.ImageReceipts"
+        static var backgroundImageReceipts = "af_UIButton.BackgroundImageReceipts"
     }
 
     // MARK: - Properties
@@ -44,10 +44,10 @@ extension UIButton {
     /// custom instance image downloader is when images are behind different basic auth credentials.
     public var af_imageDownloader: ImageDownloader? {
         get {
-            return objc_getAssociatedObject(self, &AssociatedKey.ImageDownloader) as? ImageDownloader
+            return objc_getAssociatedObject(self, &AssociatedKey.imageDownloader) as? ImageDownloader
         }
         set {
-            objc_setAssociatedObject(self, &AssociatedKey.ImageDownloader, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &AssociatedKey.imageDownloader, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
@@ -58,7 +58,7 @@ extension UIButton {
     public class var af_sharedImageDownloader: ImageDownloader {
         get {
             guard let
-                downloader = objc_getAssociatedObject(self, &AssociatedKey.SharedImageDownloader) as? ImageDownloader
+                downloader = objc_getAssociatedObject(self, &AssociatedKey.sharedImageDownloader) as? ImageDownloader
             else {
                 return ImageDownloader.default
             }
@@ -66,14 +66,14 @@ extension UIButton {
             return downloader
         }
         set {
-            objc_setAssociatedObject(self, &AssociatedKey.SharedImageDownloader, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &AssociatedKey.sharedImageDownloader, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
     private var imageRequestReceipts: [UInt: RequestReceipt] {
         get {
             guard let
-                receipts = objc_getAssociatedObject(self, &AssociatedKey.ImageReceipts) as? [UInt: RequestReceipt]
+                receipts = objc_getAssociatedObject(self, &AssociatedKey.imageReceipts) as? [UInt: RequestReceipt]
             else {
                 return [:]
             }
@@ -81,14 +81,14 @@ extension UIButton {
             return receipts
         }
         set {
-            objc_setAssociatedObject(self, &AssociatedKey.ImageReceipts, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &AssociatedKey.imageReceipts, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
     private var backgroundImageRequestReceipts: [UInt: RequestReceipt] {
         get {
             guard let
-                receipts = objc_getAssociatedObject(self, &AssociatedKey.BackgroundImageReceipts) as? [UInt: RequestReceipt]
+                receipts = objc_getAssociatedObject(self, &AssociatedKey.backgroundImageReceipts) as? [UInt: RequestReceipt]
             else {
                 return [:]
             }
@@ -96,7 +96,7 @@ extension UIButton {
             return receipts
         }
         set {
-            objc_setAssociatedObject(self, &AssociatedKey.BackgroundImageReceipts, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &AssociatedKey.backgroundImageReceipts, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 

--- a/Source/UIButton+AlamofireImage.swift
+++ b/Source/UIButton+AlamofireImage.swift
@@ -102,25 +102,23 @@ extension UIButton {
 
     // MARK: - Image Downloads
 
-    /**
-        Asynchronously downloads an image from the specified URL and sets it once the request is finished.
-
-        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
-        set immediately, and then the remote image will be set once the image request is finished.
-
-        - parameter state:            The control state of the button to set the image on.
-        - parameter URL:              The URL used for your image request.
-        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
-                                      image will not change its image until the image request finishes. Defaults
-                                      to `nil`.
-        - parameter progress:         The closure to be executed periodically during the lifecycle of the request.
-                                      Defaults to `nil`.
-        - parameter progressQueue:    The dispatch queue to call the progress closure on. Defaults to the main queue.
-        - parameter completion:       A closure to be executed when the image request finishes. The closure takes a
-                                      single response value containing either the image or the error that occurred. If
-                                      the image was returned from the image cache, the response will be `nil`. Defaults
-                                      to `nil`.
-    */
+    /// Asynchronously downloads an image from the specified URL and sets it once the request is finished.
+    ///
+    /// If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
+    /// set immediately, and then the remote image will be set once the image request is finished.
+    ///
+    /// - parameter state:            The control state of the button to set the image on.
+    /// - parameter url:              The URL used for your image request.
+    /// - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
+    ///                               image will not change its image until the image request finishes. Defaults
+    ///                               to `nil`.
+    /// - parameter progress:         The closure to be executed periodically during the lifecycle of the request.
+    ///                               Defaults to `nil`.
+    /// - parameter progressQueue:    The dispatch queue to call the progress closure on. Defaults to the main queue.
+    /// - parameter completion:       A closure to be executed when the image request finishes. The closure takes a
+    ///                               single response value containing either the image or the error that occurred. If
+    ///                               the image was returned from the image cache, the response will be `nil`. Defaults
+    ///                               to `nil`.
     public func af_setImage(
         for state: UIControlState,
         url: URL,
@@ -139,25 +137,23 @@ extension UIButton {
         )
     }
 
-    /**
-        Asynchronously downloads an image from the specified URL request and sets it once the request is finished.
-
-        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
-        set immediately, and then the remote image will be set once the image request is finished.
-
-        - parameter state:            The control state of the button to set the image on.
-        - parameter URLRequest:       The URL request.
-        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
-                                      image will not change its image until the image request finishes. Defaults
-                                      to `nil`.
-        - parameter progress:         The closure to be executed periodically during the lifecycle of the request.
-                                      Defaults to `nil`.
-        - parameter progressQueue:    The dispatch queue to call the progress closure on. Defaults to the main queue.
-        - parameter completion:       A closure to be executed when the image request finishes. The closure takes a
-                                      single response value containing either the image or the error that occurred. If
-                                      the image was returned from the image cache, the response will be `nil`. Defaults
-                                      to `nil`.
-    */
+    /// Asynchronously downloads an image from the specified URL request and sets it once the request is finished.
+    ///
+    /// If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
+    /// set immediately, and then the remote image will be set once the image request is finished.
+    ///
+    /// - parameter state:            The control state of the button to set the image on.
+    /// - parameter urlRequest:       The URL request.
+    /// - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
+    ///                               image will not change its image until the image request finishes. Defaults
+    ///                               to `nil`.
+    /// - parameter progress:         The closure to be executed periodically during the lifecycle of the request.
+    ///                               Defaults to `nil`.
+    /// - parameter progressQueue:    The dispatch queue to call the progress closure on. Defaults to the main queue.
+    /// - parameter completion:       A closure to be executed when the image request finishes. The closure takes a
+    ///                               single response value containing either the image or the error that occurred. If
+    ///                               the image was returned from the image cache, the response will be `nil`. Defaults
+    ///                               to `nil`.
     public func af_setImage(
         for state: UIControlState,
         urlRequest: URLRequestConvertible,
@@ -224,9 +220,7 @@ extension UIButton {
         setImageRequestReceipt(requestReceipt, for: state)
     }
 
-    /**
-        Cancels the active download request for the image, if one exists.
-    */
+    /// Cancels the active download request for the image, if one exists.
     public func af_cancelImageRequest(for state: UIControlState) {
         guard let receipt = imageRequestReceipt(for: state) else { return }
 
@@ -238,25 +232,23 @@ extension UIButton {
 
     // MARK: - Background Image Downloads
 
-    /**
-        Asynchronously downloads an image from the specified URL and sets it once the request is finished.
-
-        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
-        set immediately, and then the remote image will be set once the image request is finished.
-
-        - parameter state:            The control state of the button to set the image on.
-        - parameter URL:              The URL used for the image request.
-        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
-                                      background image will not change its image until the image request finishes.
-                                      Defaults to `nil`.
-        - parameter progress:         The closure to be executed periodically during the lifecycle of the request.
-                                      Defaults to `nil`.
-        - parameter progressQueue:    The dispatch queue to call the progress closure on. Defaults to the main queue.
-        - parameter completion:       A closure to be executed when the image request finishes. The closure takes a
-                                      single response value containing either the image or the error that occurred. If
-                                      the image was returned from the image cache, the response will be `nil`. Defaults
-                                      to `nil`.
-    */
+    /// Asynchronously downloads an image from the specified URL and sets it once the request is finished.
+    ///
+    /// If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
+    /// set immediately, and then the remote image will be set once the image request is finished.
+    ///
+    /// - parameter state:            The control state of the button to set the image on.
+    /// - parameter url:              The URL used for the image request.
+    /// - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
+    ///                               background image will not change its image until the image request finishes.
+    ///                               Defaults to `nil`.
+    /// - parameter progress:         The closure to be executed periodically during the lifecycle of the request.
+    ///                               Defaults to `nil`.
+    /// - parameter progressQueue:    The dispatch queue to call the progress closure on. Defaults to the main queue.
+    /// - parameter completion:       A closure to be executed when the image request finishes. The closure takes a
+    ///                               single response value containing either the image or the error that occurred. If
+    ///                               the image was returned from the image cache, the response will be `nil`. Defaults
+    ///                               to `nil`.
     public func af_setBackgroundImage(
         for state: UIControlState,
         url: URL,
@@ -272,25 +264,23 @@ extension UIButton {
             completion: completion)
     }
 
-    /**
-        Asynchronously downloads an image from the specified URL request and sets it once the request is finished.
-
-        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
-        set immediately, and then the remote image will be set once the image request is finished.
-
-        - parameter state:            The control state of the button to set the image on.
-        - parameter URLRequest:       The URL request.
-        - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
-                                      background image will not change its image until the image request finishes.
-                                      Defaults to `nil`.
-        - parameter progress:         The closure to be executed periodically during the lifecycle of the request.
-                                      Defaults to `nil`.
-        - parameter progressQueue:    The dispatch queue to call the progress closure on. Defaults to the main queue.
-        - parameter completion:       A closure to be executed when the image request finishes. The closure takes a
-                                      single response value containing either the image or the error that occurred. If
-                                      the image was returned from the image cache, the response will be `nil`. Defaults
-                                      to `nil`.
-    */
+    /// Asynchronously downloads an image from the specified URL request and sets it once the request is finished.
+    ///
+    /// If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
+    /// set immediately, and then the remote image will be set once the image request is finished.
+    ///
+    /// - parameter state:            The control state of the button to set the image on.
+    /// - parameter urlRequest:       The URL request.
+    /// - parameter placeholderImage: The image to be set initially until the image request finished. If `nil`, the
+    ///                               background image will not change its image until the image request finishes.
+    ///                               Defaults to `nil`.
+    /// - parameter progress:         The closure to be executed periodically during the lifecycle of the request.
+    ///                               Defaults to `nil`.
+    /// - parameter progressQueue:    The dispatch queue to call the progress closure on. Defaults to the main queue.
+    /// - parameter completion:       A closure to be executed when the image request finishes. The closure takes a
+    ///                               single response value containing either the image or the error that occurred. If
+    ///                               the image was returned from the image cache, the response will be `nil`. Defaults
+    ///                               to `nil`.
     public func af_setBackgroundImage(
         for state: UIControlState,
         urlRequest: URLRequestConvertible,
@@ -357,9 +347,7 @@ extension UIButton {
         setBackgroundImageRequestReceipt(requestReceipt, for: state)
     }
 
-    /**
-        Cancels the active download request for the background image, if one exists.
-    */
+    /// Cancels the active download request for the background image, if one exists.
     public func af_cancelBackgroundImageRequest(for state: UIControlState) {
         guard let receipt = backgroundImageRequestReceipt(for: state) else { return }
 

--- a/Source/UIImage+AlamofireImage.swift
+++ b/Source/UIImage+AlamofireImage.swift
@@ -35,17 +35,15 @@ import CoreImage
 private let lock = NSLock()
 
 extension UIImage {
-    /**
-        Initializes and returns the image object with the specified data in a thread-safe manner.
-
-        It has been reported that there are thread-safety issues when initializing large amounts of images
-        simultaneously. In the event of these issues occurring, this method can be used in place of
-        the `init?(data:)` method.
-
-        - parameter data: The data object containing the image data.
-
-        - returns: An initialized `UIImage` object, or `nil` if the method failed.
-    */
+    /// Initializes and returns the image object with the specified data in a thread-safe manner.
+    ///
+    /// It has been reported that there are thread-safety issues when initializing large amounts of images
+    /// simultaneously. In the event of these issues occurring, this method can be used in place of
+    /// the `init?(data:)` method.
+    ///
+    /// - parameter data: The data object containing the image data.
+    ///
+    /// - returns: An initialized `UIImage` object, or `nil` if the method failed.
     public static func af_threadSafeImage(with data: Data) -> UIImage? {
         lock.lock()
         let image = UIImage(data: data)
@@ -54,20 +52,18 @@ extension UIImage {
         return image
     }
 
-    /**
-        Initializes and returns the image object with the specified data and scale in a thread-safe manner.
-
-        It has been reported that there are thread-safety issues when initializing large amounts of images
-        simultaneously. In the event of these issues occurring, this method can be used in place of
-        the `init?(data:scale:)` method.
-
-        - parameter data:  The data object containing the image data.
-        - parameter scale: The scale factor to assume when interpreting the image data. Applying a scale factor of 1.0
-                           results in an image whose size matches the pixel-based dimensions of the image. Applying a
-                           different scale factor changes the size of the image as reported by the size property.
-
-        - returns: An initialized `UIImage` object, or `nil` if the method failed.
-    */
+    /// Initializes and returns the image object with the specified data and scale in a thread-safe manner.
+    ///
+    /// It has been reported that there are thread-safety issues when initializing large amounts of images
+    /// simultaneously. In the event of these issues occurring, this method can be used in place of
+    /// the `init?(data:scale:)` method.
+    ///
+    /// - parameter data:  The data object containing the image data.
+    /// - parameter scale: The scale factor to assume when interpreting the image data. Applying a scale factor of 1.0
+    ///                    results in an image whose size matches the pixel-based dimensions of the image. Applying a
+    ///                    different scale factor changes the size of the image as reported by the size property.
+    ///
+    /// - returns: An initialized `UIImage` object, or `nil` if the method failed.
     public static func af_threadSafeImage(with data: Data, scale: CGFloat) -> UIImage? {
         lock.lock()
         let image = UIImage(data: data, scale: scale)
@@ -98,12 +94,10 @@ extension UIImage {
         }
     }
 
-    /**
-        Inflates the underlying compressed image data to be backed by an uncompressed bitmap representation.
-
-        Inflating compressed image formats (such as PNG or JPEG) can significantly improve drawing performance as it
-        allows a bitmap representation to be constructed in the background rather than on the main thread.
-    */
+    /// Inflates the underlying compressed image data to be backed by an uncompressed bitmap representation.
+    ///
+    /// Inflating compressed image formats (such as PNG or JPEG) can significantly improve drawing performance as it
+    /// allows a bitmap representation to be constructed in the background rather than on the main thread.
     public func af_inflate() {
         guard !af_inflated else { return }
 
@@ -134,13 +128,11 @@ extension UIImage {
 // MARK: - Scaling
 
 extension UIImage {
-    /**
-        Returns a new version of the image scaled to the specified size.
-
-        - parameter size: The size to use when scaling the new image.
-
-        - returns: A new image object.
-    */
+    /// Returns a new version of the image scaled to the specified size.
+    ///
+    /// - parameter size: The size to use when scaling the new image.
+    ///
+    /// - returns: A new image object.
     public func af_imageScaledTo(_ size: CGSize) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, af_isOpaque, 0.0)
         draw(in: CGRect(origin: CGPoint.zero, size: size))
@@ -151,19 +143,17 @@ extension UIImage {
         return scaledImage!
     }
 
-    /**
-        Returns a new version of the image scaled from the center while maintaining the aspect ratio to fit within
-        a specified size.
-
-        The resulting image contains an alpha component used to pad the width or height with the necessary transparent
-        pixels to fit the specified size. In high performance critical situations, this may not be the optimal approach.
-        To maintain an opaque image, you could compute the `scaledSize` manually, then use the `af_imageScaledToSize`
-        method in conjunction with a `.Center` content mode to achieve the same visual result.
-
-        - parameter size: The size to use when scaling the new image.
-
-        - returns: A new image object.
-    */
+    /// Returns a new version of the image scaled from the center while maintaining the aspect ratio to fit within
+    /// a specified size.
+    ///
+    /// The resulting image contains an alpha component used to pad the width or height with the necessary transparent
+    /// pixels to fit the specified size. In high performance critical situations, this may not be the optimal approach.
+    /// To maintain an opaque image, you could compute the `scaledSize` manually, then use the `af_imageScaledToSize`
+    /// method in conjunction with a `.Center` content mode to achieve the same visual result.
+    ///
+    /// - parameter size: The size to use when scaling the new image.
+    ///
+    /// - returns: A new image object.
     public func af_imageAspectScaledToFit(_ size: CGSize) -> UIImage {
         let imageAspectRatio = self.size.width / self.size.height
         let canvasAspectRatio = size.width / size.height
@@ -188,14 +178,12 @@ extension UIImage {
         return scaledImage!
     }
 
-    /**
-        Returns a new version of the image scaled from the center while maintaining the aspect ratio to fill a
-        specified size. Any pixels that fall outside the specified size are clipped.
-
-        - parameter size: The size to use when scaling the new image.
-
-        - returns: A new image object.
-    */
+    /// Returns a new version of the image scaled from the center while maintaining the aspect ratio to fill a
+    /// specified size. Any pixels that fall outside the specified size are clipped.
+    ///
+    /// - parameter size: The size to use when scaling the new image.
+    ///
+    /// - returns: A new image object.
     public func af_imageAspectScaledToFill(_ size: CGSize) -> UIImage {
         let imageAspectRatio = self.size.width / self.size.height
         let canvasAspectRatio = size.width / size.height
@@ -224,18 +212,16 @@ extension UIImage {
 // MARK: - Rounded Corners
 
 extension UIImage {
-    /**
-        Returns a new version of the image with the corners rounded to the specified radius.
-
-        - parameter radius:                   The radius to use when rounding the new image.
-        - parameter divideRadiusByImageScale: Whether to divide the radius by the image scale. Set to `true` when the
-                                              image has the same resolution for all screen scales such as @1x, @2x and
-                                              @3x (i.e. single image from web server). Set to `false` for images loaded
-                                              from an asset catalog with varying resolutions for each screen scale.
-                                              `false` by default.
-
-        - returns: A new image object.
-    */
+    /// Returns a new version of the image with the corners rounded to the specified radius.
+    ///
+    /// - parameter radius:                   The radius to use when rounding the new image.
+    /// - parameter divideRadiusByImageScale: Whether to divide the radius by the image scale. Set to `true` when the
+    ///                                       image has the same resolution for all screen scales such as @1x, @2x and
+    ///                                       @3x (i.e. single image from web server). Set to `false` for images loaded
+    ///                                       from an asset catalog with varying resolutions for each screen scale.
+    ///                                       `false` by default.
+    ///
+    /// - returns: A new image object.
     public func af_imageWithRoundedCornerRadius(_ radius: CGFloat, divideRadiusByImageScale: Bool = false) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
 
@@ -252,11 +238,9 @@ extension UIImage {
         return roundedImage!
     }
 
-    /**
-        Returns a new version of the image rounded into a circle.
-
-        - returns: A new image object.
-    */
+    /// Returns a new version of the image rounded into a circle.
+    ///
+    /// - returns: A new image object.
     public func af_imageRoundedIntoCircle() -> UIImage {
         let radius = min(size.width, size.height) / 2.0
         var squareImage = self
@@ -290,14 +274,12 @@ extension UIImage {
 // MARK: - Core Image Filters
 
 extension UIImage {
-    /**
-        Returns a new version of the image using a CoreImage filter with the specified name and parameters.
-
-        - parameter filterName:       The name of the CoreImage filter to use on the new image.
-        - parameter filterParameters: The parameters to apply to the CoreImage filter.
-
-        - returns: A new image object, or `nil` if the filter failed for any reason.
-    */
+    /// Returns a new version of the image using a CoreImage filter with the specified name and parameters.
+    ///
+    /// - parameter filterName:       The name of the CoreImage filter to use on the new image.
+    /// - parameter filterParameters: The parameters to apply to the CoreImage filter.
+    ///
+    /// - returns: A new image object, or `nil` if the filter failed for any reason.
     public func af_imageWithAppliedCoreImageFilter(
         _ filterName: String,
         filterParameters: [String: Any]? = nil)

--- a/Source/UIImage+AlamofireImage.swift
+++ b/Source/UIImage+AlamofireImage.swift
@@ -46,7 +46,7 @@ extension UIImage {
 
         - returns: An initialized `UIImage` object, or `nil` if the method failed.
     */
-    public static func af_threadSafeImageWithData(_ data: Data) -> UIImage? {
+    public static func af_threadSafeImage(with data: Data) -> UIImage? {
         lock.lock()
         let image = UIImage(data: data)
         lock.unlock()
@@ -68,7 +68,7 @@ extension UIImage {
 
         - returns: An initialized `UIImage` object, or `nil` if the method failed.
     */
-    public static func af_threadSafeImageWithData(_ data: Data, scale: CGFloat) -> UIImage? {
+    public static func af_threadSafeImage(with data: Data, scale: CGFloat) -> UIImage? {
         lock.lock()
         let image = UIImage(data: data, scale: scale)
         lock.unlock()
@@ -80,21 +80,21 @@ extension UIImage {
 // MARK: - Inflation
 
 extension UIImage {
-    private struct AssociatedKeys {
-        static var InflatedKey = "af_UIImage.Inflated"
+    private struct AssociatedKey {
+        static var Inflated = "af_UIImage.Inflated"
     }
 
     /// Returns whether the image is inflated.
     public var af_inflated: Bool {
         get {
-            if let inflated = objc_getAssociatedObject(self, &AssociatedKeys.InflatedKey) as? Bool {
+            if let inflated = objc_getAssociatedObject(self, &AssociatedKey.Inflated) as? Bool {
                 return inflated
             } else {
                 return false
             }
         }
-        set(inflated) {
-            objc_setAssociatedObject(self, &AssociatedKeys.InflatedKey, inflated, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        set {
+            objc_setAssociatedObject(self, &AssociatedKey.Inflated, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
@@ -141,7 +141,7 @@ extension UIImage {
 
         - returns: A new image object.
     */
-    public func af_imageScaledToSize(_ size: CGSize) -> UIImage {
+    public func af_imageScaledTo(_ size: CGSize) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, af_isOpaque, 0.0)
         draw(in: CGRect(origin: CGPoint.zero, size: size))
 
@@ -164,7 +164,7 @@ extension UIImage {
 
         - returns: A new image object.
     */
-    public func af_imageAspectScaledToFitSize(_ size: CGSize) -> UIImage {
+    public func af_imageAspectScaledToFit(_ size: CGSize) -> UIImage {
         let imageAspectRatio = self.size.width / self.size.height
         let canvasAspectRatio = size.width / size.height
 
@@ -196,7 +196,7 @@ extension UIImage {
 
         - returns: A new image object.
     */
-    public func af_imageAspectScaledToFillSize(_ size: CGSize) -> UIImage {
+    public func af_imageAspectScaledToFill(_ size: CGSize) -> UIImage {
         let imageAspectRatio = self.size.width / self.size.height
         let canvasAspectRatio = size.width / size.height
 
@@ -264,7 +264,7 @@ extension UIImage {
         if size.width != size.height {
             let squareDimension = min(size.width, size.height)
             let squareSize = CGSize(width: squareDimension, height: squareDimension)
-            squareImage = af_imageAspectScaledToFillSize(squareSize)
+            squareImage = af_imageAspectScaledToFill(squareSize)
         }
 
         UIGraphicsBeginImageContextWithOptions(squareImage.size, false, 0.0)
@@ -300,7 +300,8 @@ extension UIImage {
     */
     public func af_imageWithAppliedCoreImageFilter(
         _ filterName: String,
-        filterParameters: [String: Any]? = nil) -> UIImage?
+        filterParameters: [String: Any]? = nil)
+        -> UIImage?
     {
         var image: CoreImage.CIImage? = ciImage
 

--- a/Source/UIImage+AlamofireImage.swift
+++ b/Source/UIImage+AlamofireImage.swift
@@ -77,20 +77,20 @@ extension UIImage {
 
 extension UIImage {
     private struct AssociatedKey {
-        static var Inflated = "af_UIImage.Inflated"
+        static var inflated = "af_UIImage.Inflated"
     }
 
     /// Returns whether the image is inflated.
     public var af_inflated: Bool {
         get {
-            if let inflated = objc_getAssociatedObject(self, &AssociatedKey.Inflated) as? Bool {
+            if let inflated = objc_getAssociatedObject(self, &AssociatedKey.inflated) as? Bool {
                 return inflated
             } else {
                 return false
             }
         }
         set {
-            objc_setAssociatedObject(self, &AssociatedKey.Inflated, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &AssociatedKey.inflated, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 

--- a/Source/UIImage+AlamofireImage.swift
+++ b/Source/UIImage+AlamofireImage.swift
@@ -133,7 +133,7 @@ extension UIImage {
     /// - parameter size: The size to use when scaling the new image.
     ///
     /// - returns: A new image object.
-    public func af_imageScaledTo(_ size: CGSize) -> UIImage {
+    public func af_imageScaled(to size: CGSize) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, af_isOpaque, 0.0)
         draw(in: CGRect(origin: CGPoint.zero, size: size))
 
@@ -154,7 +154,7 @@ extension UIImage {
     /// - parameter size: The size to use when scaling the new image.
     ///
     /// - returns: A new image object.
-    public func af_imageAspectScaledToFit(_ size: CGSize) -> UIImage {
+    public func af_imageAspectScaled(toFit size: CGSize) -> UIImage {
         let imageAspectRatio = self.size.width / self.size.height
         let canvasAspectRatio = size.width / size.height
 
@@ -184,7 +184,7 @@ extension UIImage {
     /// - parameter size: The size to use when scaling the new image.
     ///
     /// - returns: A new image object.
-    public func af_imageAspectScaledToFill(_ size: CGSize) -> UIImage {
+    public func af_imageAspectScaled(toFill size: CGSize) -> UIImage {
         let imageAspectRatio = self.size.width / self.size.height
         let canvasAspectRatio = size.width / size.height
 
@@ -222,7 +222,7 @@ extension UIImage {
     ///                                       `false` by default.
     ///
     /// - returns: A new image object.
-    public func af_imageWithRoundedCornerRadius(_ radius: CGFloat, divideRadiusByImageScale: Bool = false) -> UIImage {
+    public func af_imageRounded(withCornerRadius radius: CGFloat, divideRadiusByImageScale: Bool = false) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
 
         let scaledRadius = divideRadiusByImageScale ? radius / scale : radius
@@ -248,7 +248,7 @@ extension UIImage {
         if size.width != size.height {
             let squareDimension = min(size.width, size.height)
             let squareSize = CGSize(width: squareDimension, height: squareDimension)
-            squareImage = af_imageAspectScaledToFill(squareSize)
+            squareImage = af_imageAspectScaled(toFill: squareSize)
         }
 
         UIGraphicsBeginImageContextWithOptions(squareImage.size, false, 0.0)
@@ -276,15 +276,11 @@ extension UIImage {
 extension UIImage {
     /// Returns a new version of the image using a CoreImage filter with the specified name and parameters.
     ///
-    /// - parameter filterName:       The name of the CoreImage filter to use on the new image.
-    /// - parameter filterParameters: The parameters to apply to the CoreImage filter.
+    /// - parameter name:       The name of the CoreImage filter to use on the new image.
+    /// - parameter parameters: The parameters to apply to the CoreImage filter.
     ///
     /// - returns: A new image object, or `nil` if the filter failed for any reason.
-    public func af_imageWithAppliedCoreImageFilter(
-        _ filterName: String,
-        filterParameters: [String: Any]? = nil)
-        -> UIImage?
-    {
+    public func af_imageFiltered(withCoreImageFilter name: String, parameters: [String: Any]? = nil) -> UIImage? {
         var image: CoreImage.CIImage? = ciImage
 
         if image == nil, let CGImage = self.cgImage {
@@ -295,10 +291,10 @@ extension UIImage {
 
         let context = CIContext(options: [kCIContextPriorityRequestLow: true])
 
-        var parameters: [String: Any] = filterParameters ?? [:]
+        var parameters: [String: Any] = parameters ?? [:]
         parameters[kCIInputImageKey] = coreImage
 
-        guard let filter = CIFilter(name: filterName, withInputParameters: parameters) else { return nil }
+        guard let filter = CIFilter(name: name, withInputParameters: parameters) else { return nil }
         guard let outputImage = filter.outputImage else { return nil }
 
         let cgImageRef = context.createCGImage(outputImage, from: outputImage.extent)

--- a/Source/UIImage+AlamofireImage.swift
+++ b/Source/UIImage+AlamofireImage.swift
@@ -300,7 +300,7 @@ extension UIImage {
     */
     public func af_imageWithAppliedCoreImageFilter(
         _ filterName: String,
-        filterParameters: [String: AnyObject]? = nil) -> UIImage?
+        filterParameters: [String: Any]? = nil) -> UIImage?
     {
         var image: CoreImage.CIImage? = ciImage
 
@@ -312,7 +312,7 @@ extension UIImage {
 
         let context = CIContext(options: [kCIContextPriorityRequestLow: true])
 
-        var parameters: [String: AnyObject] = filterParameters ?? [:]
+        var parameters: [String: Any] = filterParameters ?? [:]
         parameters[kCIInputImageKey] = coreImage
 
         guard let filter = CIFilter(name: filterName, withInputParameters: parameters) else { return nil }

--- a/Source/UIImageView+AlamofireImage.swift
+++ b/Source/UIImageView+AlamofireImage.swift
@@ -119,9 +119,9 @@ extension UIImageView {
     // MARK: - Private - AssociatedKeys
 
     private struct AssociatedKey {
-        static var ImageDownloader = "af_UIImageView.ImageDownloader"
-        static var SharedImageDownloader = "af_UIImageView.SharedImageDownloader"
-        static var ActiveRequestReceipt = "af_UIImageView.ActiveRequestReceipt"
+        static var imageDownloader = "af_UIImageView.ImageDownloader"
+        static var sharedImageDownloader = "af_UIImageView.SharedImageDownloader"
+        static var activeRequestReceipt = "af_UIImageView.ActiveRequestReceipt"
     }
 
     // MARK: - Associated Properties
@@ -131,10 +131,10 @@ extension UIImageView {
     /// custom instance image downloader is when images are behind different basic auth credentials.
     public var af_imageDownloader: ImageDownloader? {
         get {
-            return objc_getAssociatedObject(self, &AssociatedKey.ImageDownloader) as? ImageDownloader
+            return objc_getAssociatedObject(self, &AssociatedKey.imageDownloader) as? ImageDownloader
         }
         set(downloader) {
-            objc_setAssociatedObject(self, &AssociatedKey.ImageDownloader, downloader, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &AssociatedKey.imageDownloader, downloader, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
@@ -144,23 +144,23 @@ extension UIImageView {
     /// `af_imageDownloader` is `nil`.
     public class var af_sharedImageDownloader: ImageDownloader {
         get {
-            if let downloader = objc_getAssociatedObject(self, &AssociatedKey.SharedImageDownloader) as? ImageDownloader {
+            if let downloader = objc_getAssociatedObject(self, &AssociatedKey.sharedImageDownloader) as? ImageDownloader {
                 return downloader
             } else {
                 return ImageDownloader.default
             }
         }
         set {
-            objc_setAssociatedObject(self, &AssociatedKey.SharedImageDownloader, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &AssociatedKey.sharedImageDownloader, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
     var af_activeRequestReceipt: RequestReceipt? {
         get {
-            return objc_getAssociatedObject(self, &AssociatedKey.ActiveRequestReceipt) as? RequestReceipt
+            return objc_getAssociatedObject(self, &AssociatedKey.activeRequestReceipt) as? RequestReceipt
         }
         set {
-            objc_setAssociatedObject(self, &AssociatedKey.ActiveRequestReceipt, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &AssociatedKey.activeRequestReceipt, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 

--- a/Source/UIImageView+AlamofireImage.swift
+++ b/Source/UIImageView+AlamofireImage.swift
@@ -166,39 +166,37 @@ extension UIImageView {
 
     // MARK: - Image Download
 
-    /**
-        Asynchronously downloads an image from the specified URL, applies the specified image filter to the downloaded
-        image and sets it once finished while executing the image transition.
-
-        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
-        set immediately, and then the remote image will be set once the image request is finished.
-
-        The `completion` closure is called after the image download and filtering are complete, but before the start of
-        the image transition. Please note it is no longer the responsibility of the `completion` closure to set the
-        image. It will be set automatically. If you require a second notification after the image transition completes,
-        use a `.Custom` image transition with a `completion` closure. The `.Custom` `completion` closure is called when
-        the image transition is finished.
-
-        - parameter URL:                        The URL used for the image request.
-        - parameter placeholderImage:           The image to be set initially until the image request finished. If
-                                                `nil`, the image view will not change its image until the image
-                                                request finishes. Defaults to `nil`.
-        - parameter filter:                     The image filter applied to the image after the image request is
-                                                finished. Defaults to `nil`.
-        - parameter progress:                   The closure to be executed periodically during the lifecycle of the
-                                                request. Defaults to `nil`.
-        - parameter progressQueue:              The dispatch queue to call the progress closure on. Defaults to the
-                                                main queue.
-        - parameter imageTransition:            The image transition animation applied to the image when set.
-                                                Defaults to `.None`.
-        - parameter runImageTransitionIfCached: Whether to run the image transition if the image is cached. Defaults
-                                                to `false`.
-        - parameter completion:                 A closure to be executed when the image request finishes. The closure
-                                                has no return value and takes three arguments: the original request,
-                                                the response from the server and the result containing either the
-                                                image or the error that occurred. If the image was returned from the
-                                                image cache, the response will be `nil`. Defaults to `nil`.
-    */
+    /// Asynchronously downloads an image from the specified URL, applies the specified image filter to the downloaded
+    /// image and sets it once finished while executing the image transition.
+    ///
+    /// If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
+    /// set immediately, and then the remote image will be set once the image request is finished.
+    ///
+    /// The `completion` closure is called after the image download and filtering are complete, but before the start of
+    /// the image transition. Please note it is no longer the responsibility of the `completion` closure to set the
+    /// image. It will be set automatically. If you require a second notification after the image transition completes,
+    /// use a `.Custom` image transition with a `completion` closure. The `.Custom` `completion` closure is called when
+    /// the image transition is finished.
+    ///
+    /// - parameter url:                        The URL used for the image request.
+    /// - parameter placeholderImage:           The image to be set initially until the image request finished. If
+    ///                                         `nil`, the image view will not change its image until the image
+    ///                                         request finishes. Defaults to `nil`.
+    /// - parameter filter:                     The image filter applied to the image after the image request is
+    ///                                         finished. Defaults to `nil`.
+    /// - parameter progress:                   The closure to be executed periodically during the lifecycle of the
+    ///                                         request. Defaults to `nil`.
+    /// - parameter progressQueue:              The dispatch queue to call the progress closure on. Defaults to the
+    ///                                         main queue.
+    /// - parameter imageTransition:            The image transition animation applied to the image when set.
+    ///                                         Defaults to `.None`.
+    /// - parameter runImageTransitionIfCached: Whether to run the image transition if the image is cached. Defaults
+    ///                                         to `false`.
+    /// - parameter completion:                 A closure to be executed when the image request finishes. The closure
+    ///                                         has no return value and takes three arguments: the original request,
+    ///                                         the response from the server and the result containing either the
+    ///                                         image or the error that occurred. If the image was returned from the
+    ///                                         image cache, the response will be `nil`. Defaults to `nil`.
     public func af_setImage(
         withURL url: URL,
         placeholderImage: UIImage? = nil,
@@ -221,39 +219,37 @@ extension UIImageView {
         )
     }
 
-    /**
-        Asynchronously downloads an image from the specified URL Request, applies the specified image filter to the downloaded
-        image and sets it once finished while executing the image transition.
-
-        If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
-        set immediately, and then the remote image will be set once the image request is finished.
-
-        The `completion` closure is called after the image download and filtering are complete, but before the start of
-        the image transition. Please note it is no longer the responsibility of the `completion` closure to set the
-        image. It will be set automatically. If you require a second notification after the image transition completes,
-        use a `.Custom` image transition with a `completion` closure. The `.Custom` `completion` closure is called when
-        the image transition is finished.
-
-        - parameter URLRequest:                 The URL request.
-        - parameter placeholderImage:           The image to be set initially until the image request finished. If
-                                                `nil`, the image view will not change its image until the image
-                                                request finishes. Defaults to `nil`.
-        - parameter filter:                     The image filter applied to the image after the image request is
-                                                finished. Defaults to `nil`.
-        - parameter progress:                   The closure to be executed periodically during the lifecycle of the
-                                                request. Defaults to `nil`.
-        - parameter progressQueue:              The dispatch queue to call the progress closure on. Defaults to the
-                                                main queue.
-        - parameter imageTransition:            The image transition animation applied to the image when set.
-                                                Defaults to `.None`.
-        - parameter runImageTransitionIfCached: Whether to run the image transition if the image is cached. Defaults
-                                                to `false`.
-        - parameter completion:                 A closure to be executed when the image request finishes. The closure
-                                                has no return value and takes three arguments: the original request,
-                                                the response from the server and the result containing either the
-                                                image or the error that occurred. If the image was returned from the
-                                                image cache, the response will be `nil`. Defaults to `nil`.
-    */
+    /// Asynchronously downloads an image from the specified URL Request, applies the specified image filter to the downloaded
+    /// image and sets it once finished while executing the image transition.
+    ///
+    /// If the image is cached locally, the image is set immediately. Otherwise the specified placehoder image will be
+    /// set immediately, and then the remote image will be set once the image request is finished.
+    ///
+    /// The `completion` closure is called after the image download and filtering are complete, but before the start of
+    /// the image transition. Please note it is no longer the responsibility of the `completion` closure to set the
+    /// image. It will be set automatically. If you require a second notification after the image transition completes,
+    /// use a `.Custom` image transition with a `completion` closure. The `.Custom` `completion` closure is called when
+    /// the image transition is finished.
+    ///
+    /// - parameter urlRequest:                 The URL request.
+    /// - parameter placeholderImage:           The image to be set initially until the image request finished. If
+    ///                                         `nil`, the image view will not change its image until the image
+    ///                                         request finishes. Defaults to `nil`.
+    /// - parameter filter:                     The image filter applied to the image after the image request is
+    ///                                         finished. Defaults to `nil`.
+    /// - parameter progress:                   The closure to be executed periodically during the lifecycle of the
+    ///                                         request. Defaults to `nil`.
+    /// - parameter progressQueue:              The dispatch queue to call the progress closure on. Defaults to the
+    ///                                         main queue.
+    /// - parameter imageTransition:            The image transition animation applied to the image when set.
+    ///                                         Defaults to `.None`.
+    /// - parameter runImageTransitionIfCached: Whether to run the image transition if the image is cached. Defaults
+    ///                                         to `false`.
+    /// - parameter completion:                 A closure to be executed when the image request finishes. The closure
+    ///                                         has no return value and takes three arguments: the original request,
+    ///                                         the response from the server and the result containing either the
+    ///                                         image or the error that occurred. If the image was returned from the
+    ///                                         image cache, the response will be `nil`. Defaults to `nil`.
     public func af_setImage(
         withURLRequest urlRequest: URLRequestConvertible,
         placeholderImage: UIImage? = nil,
@@ -334,9 +330,7 @@ extension UIImageView {
 
     // MARK: - Image Download Cancellation
 
-    /**
-        Cancels the active download request, if one exists.
-    */
+    /// Cancels the active download request, if one exists.
     public func af_cancelImageRequest() {
         guard let activeRequestReceipt = af_activeRequestReceipt else { return }
 
@@ -348,12 +342,10 @@ extension UIImageView {
 
     // MARK: - Image Transition
 
-    /**
-        Runs the image transition on the image view with the specified image.
-
-        - parameter imageTransition: The image transition to ran on the image view.
-        - parameter image:           The image to use for the image transition.
-    */
+    /// Runs the image transition on the image view with the specified image.
+    ///
+    /// - parameter imageTransition: The image transition to ran on the image view.
+    /// - parameter image:           The image to use for the image transition.
     public func run(_ imageTransition: ImageTransition, with image: Image) {
         UIView.transition(
             with: self,

--- a/Tests/BaseTestCase.swift
+++ b/Tests/BaseTestCase.swift
@@ -59,16 +59,17 @@ class BaseTestCase : XCTestCase {
 
     // MARK: - Resources
 
-    func urlForResource(_ fileName: String, withExtension ext: String) -> URL {
+    func url(forResource fileName: String, withExtension ext: String) -> URL {
         let bundle = Bundle(for: BaseTestCase.self)
         return bundle.url(forResource: fileName, withExtension: ext)!
     }
 
-    func imageForResource(_ fileName: String, withExtension ext: String) -> Image {
-        let resourceURL = urlForResource(fileName, withExtension: ext)
+    func image(forResource fileName: String, withExtension ext: String) -> Image {
+        let resourceURL = url(forResource: fileName, withExtension: ext)
         let data = try! Data(contentsOf: resourceURL)
+
         #if os(iOS) || os(tvOS)
-            let image = Image.af_threadSafeImageWithData(data, scale: UIScreen.main.scale)!
+            let image = Image.af_threadSafeImage(with: data, scale: UIScreen.main.scale)!
         #elseif os(OSX)
             let image = Image(data: data)!
         #endif

--- a/Tests/BaseTestCase.swift
+++ b/Tests/BaseTestCase.swift
@@ -29,43 +29,43 @@ import XCTest
 
 class BaseTestCase : XCTestCase {
     let timeout = 5.0
-    var manager: Manager!
+    var sessionManager: SessionManager!
 
     // MARK: - Setup and Teardown
 
     override func setUp() {
         super.setUp()
 
-        manager = {
+        sessionManager = {
             let configuration: URLSessionConfiguration = {
                 let configuration = URLSessionConfiguration.ephemeral
 
-                let defaultHeaders = Manager.sharedInstance.session.configuration.httpAdditionalHeaders
+                let defaultHeaders = SessionManager.default.session.configuration.httpAdditionalHeaders
                 configuration.httpAdditionalHeaders = defaultHeaders
 
                 return configuration
             }()
 
-            return Manager(configuration: configuration)
+            return SessionManager(configuration: configuration)
         }()
     }
 
     override func tearDown() {
         super.tearDown()
 
-        manager.session.finishTasksAndInvalidate()
-        manager = nil
+        sessionManager.session.finishTasksAndInvalidate()
+        sessionManager = nil
     }
 
     // MARK: - Resources
 
-    func URLForResource(_ fileName: String, withExtension: String) -> URL {
+    func urlForResource(_ fileName: String, withExtension ext: String) -> URL {
         let bundle = Bundle(for: BaseTestCase.self)
-        return bundle.url(forResource: fileName, withExtension: withExtension)!
+        return bundle.url(forResource: fileName, withExtension: ext)!
     }
 
     func imageForResource(_ fileName: String, withExtension ext: String) -> Image {
-        let resourceURL = URLForResource(fileName, withExtension: ext)
+        let resourceURL = urlForResource(fileName, withExtension: ext)
         let data = try! Data(contentsOf: resourceURL)
         #if os(iOS) || os(tvOS)
             let image = Image.af_threadSafeImageWithData(data, scale: UIScreen.main.scale)!

--- a/Tests/ImageCacheTests.swift
+++ b/Tests/ImageCacheTests.swift
@@ -146,11 +146,12 @@ class ImageCacheTestCase: BaseTestCase {
         cache.add(image, withIdentifier: identifier)
         let cachedImageExists = cache.image(withIdentifier: identifier) != nil
 
-        cache.removeImage(withIdentifier: identifier)
+        let removedImage = cache.removeImage(withIdentifier: identifier)
         let cachedImageExistsAfterRemoval = cache.image(withIdentifier: identifier) != nil
 
         // Then
         XCTAssertTrue(cachedImageExists, "cached image exists should be true")
+        XCTAssertTrue(removedImage, "removed image should be true")
         XCTAssertFalse(cachedImageExistsAfterRemoval, "cached image exists after removal should be false")
     }
 
@@ -164,11 +165,12 @@ class ImageCacheTestCase: BaseTestCase {
         cache.add(image, for: request, withIdentifier: identifier)
         let cachedImageExists = cache.image(for: request, withIdentifier: identifier) != nil
 
-        cache.removeImage(for: request, withIdentifier: identifier)
+        let removedImage = cache.removeImage(for: request, withIdentifier: identifier)
         let cachedImageExistsAfterRemoval = cache.image(for: request, withIdentifier: identifier) != nil
 
         // Then
         XCTAssertTrue(cachedImageExists, "cached image exists should be true")
+        XCTAssertTrue(removedImage, "removed image should be true")
         XCTAssertFalse(cachedImageExistsAfterRemoval, "cached image exists after removal should be false")
     }
 
@@ -181,11 +183,12 @@ class ImageCacheTestCase: BaseTestCase {
         cache.add(image, withIdentifier: identifier)
         let cachedImageExists = cache.image(withIdentifier: identifier) != nil
 
-        cache.removeAllImages()
+        let removedImages = cache.removeAllImages()
         let cachedImageExistsAfterRemoval = cache.image(withIdentifier: identifier) != nil
 
         // Then
         XCTAssertTrue(cachedImageExists, "cached image exists should be true")
+        XCTAssertTrue(removedImages, "removed images should be true")
         XCTAssertFalse(cachedImageExistsAfterRemoval, "cached image exists after removal should be false")
     }
 

--- a/Tests/ImageCacheTests.swift
+++ b/Tests/ImageCacheTests.swift
@@ -78,7 +78,7 @@ class ImageCacheTestCase: BaseTestCase {
     func testThatItCanAddImageToCacheWithRequestIdentifier() {
         // Given
         let image = imageForResource("unicorn", withExtension: "png")
-        let request = URLRequest(.GET, "https://images.example.com/animals")
+        let request = URLRequest(urlString: "https://images.example.com/animals", method: .get)
         let identifier = "-unicorn"
 
         // When
@@ -116,7 +116,7 @@ class ImageCacheTestCase: BaseTestCase {
         // Given
         let unicornImage = imageForResource("unicorn", withExtension: "png")
         let pirateImage = imageForResource("pirate", withExtension: "jpg")
-        let request = URLRequest(.GET, "https://images.example.com/animals")
+        let request = URLRequest(urlString: "https://images.example.com/animals", method: .get)
         let identifier = "animal"
 
         // When
@@ -157,7 +157,7 @@ class ImageCacheTestCase: BaseTestCase {
     func testThatItCanRemoveImageFromCacheWithRequestIdentifier() {
         // Given
         let image = imageForResource("unicorn", withExtension: "png")
-        let request = URLRequest(.GET, "https://images.example.com/animals")
+        let request = URLRequest(urlString: "https://images.example.com/animals", method: .get)
         let identifier = "unicorn"
 
         // When
@@ -234,7 +234,7 @@ class ImageCacheTestCase: BaseTestCase {
     func testThatItCanFetchImageFromCacheWithRequestIdentifier() {
         // Given
         let image = imageForResource("unicorn", withExtension: "png")
-        let request = URLRequest(.GET, "https://images.example.com/animals")
+        let request = URLRequest(urlString: "https://images.example.com/animals", method: .get)
         let identifier = "unicorn"
 
         // When

--- a/Tests/ImageCacheTests.swift
+++ b/Tests/ImageCacheTests.swift
@@ -63,12 +63,12 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatItCanAddImageToCacheWithIdentifier() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let identifier = "unicorn"
 
         // When
-        cache.addImage(image, withIdentifier: identifier)
-        let cachedImage = cache.imageWithIdentifier(identifier)
+        cache.add(image, withIdentifier: identifier)
+        let cachedImage = cache.image(withIdentifier: identifier)
 
         // Then
         XCTAssertNotNil(cachedImage, "cached image should not be nil")
@@ -77,13 +77,13 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatItCanAddImageToCacheWithRequestIdentifier() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let request = URLRequest(urlString: "https://images.example.com/animals", method: .get)
         let identifier = "-unicorn"
 
         // When
-        cache.addImage(image, forRequest: request, withAdditionalIdentifier: identifier)
-        let cachedImage = cache.imageForRequest(request, withAdditionalIdentifier: identifier)
+        cache.add(image, for: request, withIdentifier: identifier)
+        let cachedImage = cache.image(for: request, withIdentifier: identifier)
 
         // Then
         XCTAssertNotNil(cachedImage, "cached image should not be nil")
@@ -92,16 +92,16 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatAddingImageToCacheWithDuplicateIdentifierReplacesCachedImage() {
         // Given
-        let unicornImage = imageForResource("unicorn", withExtension: "png")
-        let pirateImage = imageForResource("pirate", withExtension: "jpg")
+        let unicornImage = image(forResource: "unicorn", withExtension: "png")
+        let pirateImage = image(forResource: "pirate", withExtension: "jpg")
         let identifier = "animal"
 
         // When
-        cache.addImage(unicornImage, withIdentifier: identifier)
-        let cachedImage1 = cache.imageWithIdentifier(identifier)
+        cache.add(unicornImage, withIdentifier: identifier)
+        let cachedImage1 = cache.image(withIdentifier: identifier)
 
-        cache.addImage(pirateImage, withIdentifier: identifier)
-        let cachedImage2 = cache.imageWithIdentifier(identifier)
+        cache.add(pirateImage, withIdentifier: identifier)
+        let cachedImage2 = cache.image(withIdentifier: identifier)
 
         // Then
         XCTAssertNotNil(cachedImage1, "cached image 1 should not be nil")
@@ -114,17 +114,17 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatAddingImageToCacheWithDuplicateRequestIdentifierReplacesCachedImage() {
         // Given
-        let unicornImage = imageForResource("unicorn", withExtension: "png")
-        let pirateImage = imageForResource("pirate", withExtension: "jpg")
+        let unicornImage = image(forResource: "unicorn", withExtension: "png")
+        let pirateImage = image(forResource: "pirate", withExtension: "jpg")
         let request = URLRequest(urlString: "https://images.example.com/animals", method: .get)
         let identifier = "animal"
 
         // When
-        cache.addImage(unicornImage, forRequest: request, withAdditionalIdentifier: identifier)
-        let cachedImage1 = cache.imageForRequest(request, withAdditionalIdentifier: identifier)
+        cache.add(unicornImage, for: request, withIdentifier: identifier)
+        let cachedImage1 = cache.image(for: request, withIdentifier: identifier)
 
-        cache.addImage(pirateImage, forRequest: request, withAdditionalIdentifier: identifier)
-        let cachedImage2 = cache.imageForRequest(request, withAdditionalIdentifier: identifier)
+        cache.add(pirateImage, for: request, withIdentifier: identifier)
+        let cachedImage2 = cache.image(for: request, withIdentifier: identifier)
 
         // Then
         XCTAssertNotNil(cachedImage1, "cached image 1 should not be nil")
@@ -139,15 +139,15 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatItCanRemoveImageFromCacheWithIdentifier() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let identifier = "unicorn"
 
         // When
-        cache.addImage(image, withIdentifier: identifier)
-        let cachedImageExists = cache.imageWithIdentifier(identifier) != nil
+        cache.add(image, withIdentifier: identifier)
+        let cachedImageExists = cache.image(withIdentifier: identifier) != nil
 
-        cache.removeImageWithIdentifier(identifier)
-        let cachedImageExistsAfterRemoval = cache.imageWithIdentifier(identifier) != nil
+        cache.removeImage(withIdentifier: identifier)
+        let cachedImageExistsAfterRemoval = cache.image(withIdentifier: identifier) != nil
 
         // Then
         XCTAssertTrue(cachedImageExists, "cached image exists should be true")
@@ -156,16 +156,16 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatItCanRemoveImageFromCacheWithRequestIdentifier() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let request = URLRequest(urlString: "https://images.example.com/animals", method: .get)
         let identifier = "unicorn"
 
         // When
-        cache.addImage(image, forRequest: request, withAdditionalIdentifier: identifier)
-        let cachedImageExists = cache.imageForRequest(request, withAdditionalIdentifier: identifier) != nil
+        cache.add(image, for: request, withIdentifier: identifier)
+        let cachedImageExists = cache.image(for: request, withIdentifier: identifier) != nil
 
-        cache.removeImageForRequest(request, withAdditionalIdentifier: identifier)
-        let cachedImageExistsAfterRemoval = cache.imageForRequest(request, withAdditionalIdentifier: identifier) != nil
+        cache.removeImage(for: request, withIdentifier: identifier)
+        let cachedImageExistsAfterRemoval = cache.image(for: request, withIdentifier: identifier) != nil
 
         // Then
         XCTAssertTrue(cachedImageExists, "cached image exists should be true")
@@ -174,15 +174,15 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatItCanRemoveAllImagesFromCache() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let identifier = "unicorn"
 
         // When
-        cache.addImage(image, withIdentifier: identifier)
-        let cachedImageExists = cache.imageWithIdentifier(identifier) != nil
+        cache.add(image, withIdentifier: identifier)
+        let cachedImageExists = cache.image(withIdentifier: identifier) != nil
 
         cache.removeAllImages()
-        let cachedImageExistsAfterRemoval = cache.imageWithIdentifier(identifier) != nil
+        let cachedImageExistsAfterRemoval = cache.image(withIdentifier: identifier) != nil
 
         // Then
         XCTAssertTrue(cachedImageExists, "cached image exists should be true")
@@ -193,19 +193,19 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatItRemovesAllImagesFromCacheWhenReceivingMemoryWarningNotification() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let identifier = "unicorn"
 
         // When
-        cache.addImage(image, withIdentifier: identifier)
-        let cachedImageExists = cache.imageWithIdentifier(identifier) != nil
+        cache.add(image, withIdentifier: identifier)
+        let cachedImageExists = cache.image(withIdentifier: identifier) != nil
 
         NotificationCenter.default.post(
             name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning,
             object: nil
         )
 
-        let cachedImageExistsAfterNotification = cache.imageWithIdentifier(identifier) != nil
+        let cachedImageExistsAfterNotification = cache.image(withIdentifier: identifier) != nil
 
         // Then
         XCTAssertTrue(cachedImageExists, "cached image exists should be true")
@@ -218,13 +218,13 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatItCanFetchImageFromCacheWithIdentifier() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let identifier = "unicorn"
 
         // When
-        let cachedImageBeforeAdd = cache.imageWithIdentifier(identifier)
-        cache.addImage(image, withIdentifier: identifier)
-        let cachedImageAfterAdd = cache.imageWithIdentifier(identifier)
+        let cachedImageBeforeAdd = cache.image(withIdentifier: identifier)
+        cache.add(image, withIdentifier: identifier)
+        let cachedImageAfterAdd = cache.image(withIdentifier: identifier)
 
         // Then
         XCTAssertNil(cachedImageBeforeAdd, "cached image before add should be nil")
@@ -233,14 +233,14 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatItCanFetchImageFromCacheWithRequestIdentifier() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let request = URLRequest(urlString: "https://images.example.com/animals", method: .get)
         let identifier = "unicorn"
 
         // When
-        let cachedImageBeforeAdd = cache.imageForRequest(request, withAdditionalIdentifier: identifier)
-        cache.addImage(image, forRequest: request, withAdditionalIdentifier: identifier)
-        let cachedImageAfterAdd = cache.imageForRequest(request, withAdditionalIdentifier: identifier)
+        let cachedImageBeforeAdd = cache.image(for: request, withIdentifier: identifier)
+        cache.add(image, for: request, withIdentifier: identifier)
+        let cachedImageAfterAdd = cache.image(for: request, withIdentifier: identifier)
 
         // Then
         XCTAssertNil(cachedImageBeforeAdd, "cached image before add should be nil")
@@ -251,12 +251,12 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatItIncrementsMemoryUsageWhenAddingImageToCache() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let identifier = "unicorn"
 
         // When
         let initialMemoryUsage = cache.memoryUsage
-        cache.addImage(image, withIdentifier: identifier)
+        cache.add(image, withIdentifier: identifier)
         let currentMemoryUsage = cache.memoryUsage
 
         // Then
@@ -266,13 +266,13 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatItDecrementsMemoryUsageWhenRemovingImageFromCache() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let identifier = "unicorn"
 
         // When
-        cache.addImage(image, withIdentifier: identifier)
+        cache.add(image, withIdentifier: identifier)
         let initialMemoryUsage = cache.memoryUsage
-        cache.removeImageWithIdentifier(identifier)
+        cache.removeImage(withIdentifier: identifier)
         let currentMemoryUsage = cache.memoryUsage
 
         // Then
@@ -282,11 +282,11 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatItDecrementsMemoryUsageWhenRemovingAllImagesFromCache() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let identifier = "unicorn"
 
         // When
-        cache.addImage(image, withIdentifier: identifier)
+        cache.add(image, withIdentifier: identifier)
         let initialMemoryUsage = cache.memoryUsage
         cache.removeAllImages()
         let currentMemoryUsage = cache.memoryUsage
@@ -300,14 +300,14 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatItPurgesImagesWhenMemoryCapacityIsReached() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let identifier = "unicorn"
 
         var memoryUsage: [UInt64] = []
 
         // When
         for index in 1...640 {
-            cache.addImage(image, withIdentifier: "\(identifier)-\(index)")
+            cache.add(image, withIdentifier: "\(identifier)-\(index)")
             memoryUsage.append(cache.memoryUsage)
         }
 
@@ -320,50 +320,50 @@ class ImageCacheTestCase: BaseTestCase {
 
     func testThatItPrioritizesImagesWithOldestLastAccessDatesDuringPurge() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let identifier = "unicorn"
 
         // When
         for index in 1...640 {
-            cache.addImage(image, withIdentifier: "\(identifier)-\(index)")
+            cache.add(image, withIdentifier: "\(identifier)-\(index)")
         }
 
         // Then
         for index in 1...257 {
-            let cachedImage = cache.imageWithIdentifier("\(identifier)-\(index)")
+            let cachedImage = cache.image(withIdentifier: "\(identifier)-\(index)")
             XCTAssertNil(cachedImage, "cached image with identifier: \"\(identifier)-\(index)\" should be nil")
         }
 
         for index in 258...640 {
-            let cachedImage = cache.imageWithIdentifier("\(identifier)-\(index)")
+            let cachedImage = cache.image(withIdentifier: "\(identifier)-\(index)")
             XCTAssertNotNil(cachedImage, "cached image with identifier: \"\(identifier)-\(index)\" should not be nil")
         }
     }
 
     func testThatAccessingCachedImageUpdatesLastAccessDate() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let identifier = "unicorn"
 
         // When
         for index in 1...639 {
-            cache.addImage(image, withIdentifier: "\(identifier)-\(index)")
+            cache.add(image, withIdentifier: "\(identifier)-\(index)")
         }
 
-        _ = cache.imageWithIdentifier("\(identifier)-1")
-        cache.addImage(image, withIdentifier: "\(identifier)-640")
+        _ = cache.image(withIdentifier: "\(identifier)-1")
+        cache.add(image, withIdentifier: "\(identifier)-640")
 
         // Then
-        let firstCachedImage = cache.imageWithIdentifier("\(identifier)-1")
+        let firstCachedImage = cache.image(withIdentifier: "\(identifier)-1")
         XCTAssertNotNil(firstCachedImage, "first cached image should not be nil")
 
         for index in 2...258 {
-            let cachedImage = cache.imageWithIdentifier("\(identifier)-\(index)")
+            let cachedImage = cache.image(withIdentifier: "\(identifier)-\(index)")
             XCTAssertNil(cachedImage, "cached image with identifier: \"\(identifier)-\(index)\" should be nil")
         }
 
         for index in 259...640 {
-            let cachedImage = cache.imageWithIdentifier("\(identifier)-\(index)")
+            let cachedImage = cache.image(withIdentifier: "\(identifier)-\(index)")
             XCTAssertNotNil(cachedImage, "cached image with identifier: \"\(identifier)-\(index)\" should not be nil")
         }
     }

--- a/Tests/ImageCacheTests.swift
+++ b/Tests/ImageCacheTests.swift
@@ -204,7 +204,7 @@ class ImageCacheTestCase: BaseTestCase {
         let cachedImageExists = cache.image(withIdentifier: identifier) != nil
 
         NotificationCenter.default.post(
-            name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning,
+            name: Notification.Name.UIApplicationDidReceiveMemoryWarning,
             object: nil
         )
 

--- a/Tests/ImageDownloaderTests.swift
+++ b/Tests/ImageDownloaderTests.swift
@@ -91,7 +91,7 @@ class ImageDownloaderTestCase: BaseTestCase {
 
     func testThatImageDownloaderCanBeInitializedWithManagerInstanceAndDeinitialized() {
         // Given
-        var downloader: ImageDownloader? = ImageDownloader(sessionManager: Manager())
+        var downloader: ImageDownloader? = ImageDownloader(sessionManager: SessionManager())
 
         // When
         downloader = nil
@@ -102,10 +102,11 @@ class ImageDownloaderTestCase: BaseTestCase {
 
     func testThatImageDownloaderCanBeInitializedAndDeinitializedWithActiveDownloads() {
         // Given
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
         var downloader: ImageDownloader? = ImageDownloader()
 
         // When
-        let _ = downloader?.downloadImage(urlRequest: URLRequest(.GET, "https://httpbin.org/image/png")) { _ in
+        let _ = downloader?.downloadImage(urlRequest: urlRequest) { _ in
             // No-op
         }
 
@@ -120,7 +121,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCanDownloadAnImage() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         var response: Response<Image, NSError>?
@@ -144,8 +145,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let download1 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
-        let download2 = URLRequest(.GET, "https://httpbin.org/image/png")
+        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let download2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
 
         let expectation1 = expectation(description: "download 1 should succeed")
         let expectation2 = expectation(description: "download 2 should succeed")
@@ -182,8 +183,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let download1 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
-        let download2 = URLRequest(.GET, "https://httpbin.org/image/png")
+        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let download2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
 
         let expectation = self.expectation(description: "both downloads should succeed")
         var completedDownloads = 0
@@ -213,8 +214,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader(maximumActiveDownloads: 1)
 
-        let download1 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
-        let download2 = URLRequest(.GET, "https://httpbin.org/image/png")
+        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let download2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
 
         // When
         let requestReceipt1 = downloader.downloadImage(urlRequest: download1) { _ in
@@ -236,7 +237,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCallsTheCompletionHandlerEvenWhenDownloadFails() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/get")
+        let download = URLRequest(urlString: "https://httpbin.org/get", method: .get)
         let expectation = self.expectation(description: "download request should fail")
 
         var response: Response<Image, NSError>?
@@ -269,7 +270,7 @@ class ImageDownloaderTestCase: BaseTestCase {
             return downloader
         }()
 
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         var response: Response<Image, NSError>?
@@ -295,7 +296,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCanDownloadImageAndApplyImageFilter() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let scaledSize = CGSize(width: 100, height: 60)
         let filter = ScaledToSizeFilter(size: scaledSize)
 
@@ -325,8 +326,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let download1 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
-        let download2 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let download2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let filter1 = ScaledToSizeFilter(size: CGSize(width: 50, height: 50))
         let filter2 = ScaledToSizeFilter(size: CGSize(width: 75, height: 75))
@@ -372,8 +373,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let download1 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
-        let download2 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let download2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let filter1 = TestCircleFilter()
         let filter2 = TestCircleFilter()
@@ -417,7 +418,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCallsTheProgressHandlerOnTheMainQueueByDefault() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let progressExpectation = expectation(description: "progress closure should be called")
         let completedExpectation = expectation(description: "download request should succeed")
@@ -449,7 +450,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCallsTheProgressHandlerOnTheProgressQueue() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let progressExpectation = expectation(description: "progress closure should be called")
         let completedExpectation = expectation(description: "download request should succeed")
@@ -485,7 +486,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatCancellingDownloadCallsCompletionWithCancellationError() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let expectation = self.expectation(description: "download request should succeed")
 
@@ -518,8 +519,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let download1 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
-        let download2 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let download2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let expectation1 = expectation(description: "download request 1 should succeed")
         let expectation2 = expectation(description: "download request 2 should succeed")
@@ -568,7 +569,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItDoesNotAttachAuthenticationCredentialToRequestIfItDoesNotExist() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         // When
         let requestReceipt = downloader.downloadImage(urlRequest: download) { _ in
@@ -585,7 +586,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItAttachsUsernamePasswordCredentialToRequestIfItExists() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         // When
         downloader.addAuthentication(user: "foo", password: "bar")
@@ -604,7 +605,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItAttachsAuthenticationCredentialToRequestIfItExists() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         // When
         let credential = URLCredential(user: "foo", password: "bar", persistence: .forSession)
@@ -626,7 +627,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItAlwaysCallsTheCompletionHandlerOnTheMainQueue() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let expectation = self.expectation(description: "download request should succeed")
 
@@ -647,7 +648,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItNeverCallsTheImageFilterOnTheMainQueue() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let filter = ThreadCheckFilter()
 
         let expectation = self.expectation(description: "download request should succeed")
@@ -668,7 +669,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatCachedImageIsReturnedIfAllowedByCachePolicy() {
         // Given
         let downloader = ImageDownloader()
-        let download1 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let expectation1 = expectation(description: "image download should succeed")
 
@@ -679,7 +680,7 @@ class ImageDownloaderTestCase: BaseTestCase {
 
         waitForExpectations(timeout: timeout, handler: nil)
 
-        var download2 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        var download2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         download2.cachePolicy = .returnCacheDataElseLoad
 
         let expectation2 = expectation(description: "image download should succeed")
@@ -698,7 +699,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatCachedImageIsNotReturnedIfNotAllowedByCachePolicy() {
         // Given
         let downloader = ImageDownloader()
-        let download1 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let expectation1 = expectation(description: "image download should succeed")
 
@@ -709,7 +710,7 @@ class ImageDownloaderTestCase: BaseTestCase {
 
         waitForExpectations(timeout: timeout, handler: nil)
 
-        var download2 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        var download2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         download2.cachePolicy = .reloadIgnoringLocalCacheData
 
         let expectation2 = expectation(description: "image download should succeed")
@@ -728,7 +729,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCanDownloadImagesWhenNoImageCacheIsAvailable() {
         // Given
         let downloader = ImageDownloader(imageCache: nil)
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         var response: Response<Image, NSError>?
@@ -750,7 +751,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItAutomaticallyCachesDownloadedImageIfCacheIsAvailable() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let expectation1 = expectation(description: "image download should succeed")
 
@@ -794,7 +795,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatFilteredImageIsStoredInCacheIfCacheIsAvailable() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let size  = CGSize(width: 20, height: 20)
         let filter = ScaledToSizeFilter(size: size)
 
@@ -846,7 +847,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatStartingRequestIncrementsActiveRequestCount() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let request = downloader.sessionManager.request(download)
 
         // When
@@ -865,8 +866,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let download1 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
-        let download2 = URLRequest(.GET, "https://httpbin.org/image/png")
+        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let download2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
 
         let request1 = downloader.sessionManager.request(download1)
         let request2 = downloader.sessionManager.request(download2)
@@ -887,8 +888,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader(downloadPrioritization: .lifo)
 
-        let download1 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
-        let download2 = URLRequest(.GET, "https://httpbin.org/image/png")
+        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let download2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
 
         let request1 = downloader.sessionManager.request(download1)
         let request2 = downloader.sessionManager.request(download2)
@@ -909,8 +910,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader(downloadPrioritization: .fifo)
 
-        let download1 = URLRequest(.GET, "https://httpbin.org/image/jpeg")
-        let download2 = URLRequest(.GET, "https://httpbin.org/image/png")
+        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let download2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
 
         let request1 = downloader.sessionManager.request(download1)
         let request2 = downloader.sessionManager.request(download2)

--- a/Tests/ImageDownloaderTests.swift
+++ b/Tests/ImageDownloaderTests.swift
@@ -72,7 +72,7 @@ class ImageDownloaderTestCase: BaseTestCase {
 
     func testThatImageDownloaderSingletonCanBeInitialized() {
         // Given, When
-        let downloader = ImageDownloader.defaultInstance
+        let downloader = ImageDownloader.default
 
         // Then
         XCTAssertNotNil(downloader, "downloader should not be nil")
@@ -106,7 +106,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         var downloader: ImageDownloader? = ImageDownloader()
 
         // When
-        let _ = downloader?.downloadImage(urlRequest: urlRequest) { _ in
+        let _ = downloader?.download(urlRequest) { _ in
             // No-op
         }
 
@@ -121,13 +121,13 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCanDownloadAnImage() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         var response: Response<Image, NSError>?
 
         // When
-        downloader.downloadImage(urlRequest: download) { closureResponse in
+        downloader.download(urlRequest) { closureResponse in
             response = closureResponse
             expectation.fulfill()
         }
@@ -145,8 +145,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
-        let download2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
+        let urlRequest1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
 
         let expectation1 = expectation(description: "download 1 should succeed")
         let expectation2 = expectation(description: "download 2 should succeed")
@@ -155,12 +155,12 @@ class ImageDownloaderTestCase: BaseTestCase {
         var result2: Result<Image, NSError>?
 
         // When
-        downloader.downloadImage(urlRequest: download1) { closureResponse in
+        downloader.download(urlRequest1) { closureResponse in
             result1 = closureResponse.result
             expectation1.fulfill()
         }
 
-        downloader.downloadImage(urlRequest: download2) { closureResponse in
+        downloader.download(urlRequest2) { closureResponse in
             result2 = closureResponse.result
             expectation2.fulfill()
         }
@@ -183,8 +183,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
-        let download2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
+        let urlRequest1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
 
         let expectation = self.expectation(description: "both downloads should succeed")
         var completedDownloads = 0
@@ -192,7 +192,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         var results: [Result<Image, NSError>] = []
 
         // When
-        downloader.downloadImages(urlRequests: [download1, download2], filter: nil) { closureResponse in
+        downloader.download([urlRequest1, urlRequest2], filter: nil) { closureResponse in
             results.append(closureResponse.result)
 
             completedDownloads += 1
@@ -214,15 +214,15 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader(maximumActiveDownloads: 1)
 
-        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
-        let download2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
+        let urlRequest1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
 
         // When
-        let requestReceipt1 = downloader.downloadImage(urlRequest: download1) { _ in
+        let requestReceipt1 = downloader.download(urlRequest1) { _ in
             // No-op
         }
 
-        let requestReceipt2 = downloader.downloadImage(urlRequest: download2) { _ in
+        let requestReceipt2 = downloader.download(urlRequest2) { _ in
             // No-op
         }
 
@@ -237,13 +237,13 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCallsTheCompletionHandlerEvenWhenDownloadFails() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/get", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/get", method: .get)
         let expectation = self.expectation(description: "download request should fail")
 
         var response: Response<Image, NSError>?
 
         // When
-        downloader.downloadImage(urlRequest: download) { closureResponse in
+        downloader.download(urlRequest) { closureResponse in
             response = closureResponse
             expectation.fulfill()
         }
@@ -270,13 +270,13 @@ class ImageDownloaderTestCase: BaseTestCase {
             return downloader
         }()
 
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         var response: Response<Image, NSError>?
 
         // When
-        downloader.downloadImage(urlRequest: download) { closureResponse in
+        downloader.download(urlRequest) { closureResponse in
             response = closureResponse
             expectation.fulfill()
         }
@@ -296,7 +296,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCanDownloadImageAndApplyImageFilter() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let scaledSize = CGSize(width: 100, height: 60)
         let filter = ScaledToSizeFilter(size: scaledSize)
 
@@ -305,7 +305,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         var response: Response<Image, NSError>?
 
         // When
-        downloader.downloadImage(urlRequest: download, filter: filter) { closureResponse in
+        downloader.download(urlRequest, filter: filter) { closureResponse in
             response = closureResponse
             expectation.fulfill()
         }
@@ -326,8 +326,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
-        let download2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let filter1 = ScaledToSizeFilter(size: CGSize(width: 50, height: 50))
         let filter2 = ScaledToSizeFilter(size: CGSize(width: 75, height: 75))
@@ -339,12 +339,12 @@ class ImageDownloaderTestCase: BaseTestCase {
         var result2: Result<Image, NSError>?
 
         // When
-        let requestReceipt1 = downloader.downloadImage(urlRequest: download1, filter: filter1) { closureResponse in
+        let requestReceipt1 = downloader.download(urlRequest1, filter: filter1) { closureResponse in
             result1 = closureResponse.result
             expectation1.fulfill()
         }
 
-        let requestReceipt2 = downloader.downloadImage(urlRequest: download2, filter: filter2) { closureResponse in
+        let requestReceipt2 = downloader.download(urlRequest2, filter: filter2) { closureResponse in
             result2 = closureResponse.result
             expectation2.fulfill()
         }
@@ -373,8 +373,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
-        let download2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let filter1 = TestCircleFilter()
         let filter2 = TestCircleFilter()
@@ -386,12 +386,12 @@ class ImageDownloaderTestCase: BaseTestCase {
         var result2: Result<Image, NSError>?
 
         // When
-        let requestReceipt1 = downloader.downloadImage(urlRequest: download1, filter: filter1) { closureResponse in
+        let requestReceipt1 = downloader.download(urlRequest1, filter: filter1) { closureResponse in
             result1 = closureResponse.result
             expectation1.fulfill()
         }
 
-        let requestReceipt2 = downloader.downloadImage(urlRequest: download2, filter: filter2) { closureResponse in
+        let requestReceipt2 = downloader.download(urlRequest2, filter: filter2) { closureResponse in
             result2 = closureResponse.result
             expectation2.fulfill()
         }
@@ -418,7 +418,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCallsTheProgressHandlerOnTheMainQueueByDefault() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let progressExpectation = expectation(description: "progress closure should be called")
         let completedExpectation = expectation(description: "download request should succeed")
@@ -427,8 +427,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         var calledOnMainQueue = false
 
         // When
-        downloader.downloadImage(
-            urlRequest: download,
+        downloader.download(
+            urlRequest,
             progress: { _, _, _ in
                 if progressCalled == false {
                     progressCalled = true
@@ -450,7 +450,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCallsTheProgressHandlerOnTheProgressQueue() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let progressExpectation = expectation(description: "progress closure should be called")
         let completedExpectation = expectation(description: "download request should succeed")
@@ -459,8 +459,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         var calledOnExpectedQueue = false
 
         // When
-        downloader.downloadImage(
-            urlRequest: download,
+        downloader.download(
+            urlRequest,
             progress: { _, _, _ in
                 if progressCalled == false {
                     progressCalled = true
@@ -486,19 +486,19 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatCancellingDownloadCallsCompletionWithCancellationError() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let expectation = self.expectation(description: "download request should succeed")
 
         var response: Response<Image, NSError>?
 
         // When
-        let requestReceipt = downloader.downloadImage(urlRequest: download) { closureResponse in
+        let requestReceipt = downloader.download(urlRequest) { closureResponse in
             response = closureResponse
             expectation.fulfill()
         }
 
-        downloader.cancelRequestForRequestReceipt(requestReceipt!)
+        downloader.cancelRequest(with: requestReceipt!)
 
         waitForExpectations(timeout: timeout, handler: nil)
 
@@ -519,8 +519,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
-        let download2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let expectation1 = expectation(description: "download request 1 should succeed")
         let expectation2 = expectation(description: "download request 2 should succeed")
@@ -529,17 +529,17 @@ class ImageDownloaderTestCase: BaseTestCase {
         var response2: Response<Image, NSError>?
 
         // When
-        let requestReceipt1 = downloader.downloadImage(urlRequest: download1) { closureResponse in
+        let requestReceipt1 = downloader.download(urlRequest1) { closureResponse in
             response1 = closureResponse
             expectation1.fulfill()
         }
 
-        let requestReceipt2 = downloader.downloadImage(urlRequest: download2) { closureResponse in
+        let requestReceipt2 = downloader.download(urlRequest2) { closureResponse in
             response2 = closureResponse
             expectation2.fulfill()
         }
 
-        downloader.cancelRequestForRequestReceipt(requestReceipt1!)
+        downloader.cancelRequest(with: requestReceipt1!)
 
         waitForExpectations(timeout: timeout, handler: nil)
 
@@ -569,10 +569,10 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItDoesNotAttachAuthenticationCredentialToRequestIfItDoesNotExist() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         // When
-        let requestReceipt = downloader.downloadImage(urlRequest: download) { _ in
+        let requestReceipt = downloader.download(urlRequest) { _ in
             // No-op
         }
 
@@ -586,12 +586,12 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItAttachsUsernamePasswordCredentialToRequestIfItExists() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         // When
         downloader.addAuthentication(user: "foo", password: "bar")
 
-        let requestReceipt = downloader.downloadImage(urlRequest: download) { _ in
+        let requestReceipt = downloader.download(urlRequest) { _ in
             // No-op
         }
 
@@ -605,13 +605,13 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItAttachsAuthenticationCredentialToRequestIfItExists() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         // When
         let credential = URLCredential(user: "foo", password: "bar", persistence: .forSession)
         downloader.addAuthentication(usingCredential: credential)
 
-        let requestReceipt = downloader.downloadImage(urlRequest: download) { _ in
+        let requestReceipt = downloader.download(urlRequest) { _ in
             // No-op
         }
 
@@ -627,14 +627,14 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItAlwaysCallsTheCompletionHandlerOnTheMainQueue() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let expectation = self.expectation(description: "download request should succeed")
 
         var calledOnMainQueue = false
 
         // When
-        downloader.downloadImage(urlRequest: download) { _ in
+        downloader.download(urlRequest) { _ in
             calledOnMainQueue = Thread.isMainThread
             expectation.fulfill()
         }
@@ -648,13 +648,13 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItNeverCallsTheImageFilterOnTheMainQueue() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let filter = ThreadCheckFilter()
 
         let expectation = self.expectation(description: "download request should succeed")
 
         // When
-        downloader.downloadImage(urlRequest: download, filter: filter) { _ in
+        downloader.download(urlRequest, filter: filter) { _ in
             expectation.fulfill()
         }
 
@@ -669,23 +669,23 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatCachedImageIsReturnedIfAllowedByCachePolicy() {
         // Given
         let downloader = ImageDownloader()
-        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let expectation1 = expectation(description: "image download should succeed")
 
         // When
-        let requestReceipt1 = downloader.downloadImage(urlRequest: download1) { _ in
+        let requestReceipt1 = downloader.download(urlRequest1) { _ in
             expectation1.fulfill()
         }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
-        var download2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
-        download2.cachePolicy = .returnCacheDataElseLoad
+        var urlRequest2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        urlRequest2.cachePolicy = .returnCacheDataElseLoad
 
         let expectation2 = expectation(description: "image download should succeed")
 
-        let requestReceipt2 = downloader.downloadImage(urlRequest: download2) { _ in
+        let requestReceipt2 = downloader.download(urlRequest2) { _ in
             expectation2.fulfill()
         }
 
@@ -699,23 +699,23 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatCachedImageIsNotReturnedIfNotAllowedByCachePolicy() {
         // Given
         let downloader = ImageDownloader()
-        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let expectation1 = expectation(description: "image download should succeed")
 
         // When
-        let requestReceipt1 = downloader.downloadImage(urlRequest: download1) { _ in
+        let requestReceipt1 = downloader.download(urlRequest1) { _ in
             expectation1.fulfill()
         }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
-        var download2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
-        download2.cachePolicy = .reloadIgnoringLocalCacheData
+        var urlRequest2 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        urlRequest2.cachePolicy = .reloadIgnoringLocalCacheData
 
         let expectation2 = expectation(description: "image download should succeed")
 
-        let requestReceipt2 = downloader.downloadImage(urlRequest: download2) { _ in
+        let requestReceipt2 = downloader.download(urlRequest2) { _ in
             expectation2.fulfill()
         }
 
@@ -729,13 +729,13 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCanDownloadImagesWhenNoImageCacheIsAvailable() {
         // Given
         let downloader = ImageDownloader(imageCache: nil)
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         var response: Response<Image, NSError>?
 
         // When
-        downloader.downloadImage(urlRequest: download) { closureResponse in
+        downloader.download(urlRequest) { closureResponse in
             response = closureResponse
             expectation.fulfill()
         }
@@ -751,7 +751,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItAutomaticallyCachesDownloadedImageIfCacheIsAvailable() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
 
         let expectation1 = expectation(description: "image download should succeed")
 
@@ -759,7 +759,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         var result2: Result<Image, NSError>?
 
         // When
-        let requestReceipt1 = downloader.downloadImage(urlRequest: download) { closureResponse in
+        let requestReceipt1 = downloader.download(urlRequest) { closureResponse in
             result1 = closureResponse.result
             expectation1.fulfill()
         }
@@ -768,7 +768,7 @@ class ImageDownloaderTestCase: BaseTestCase {
 
         let expectation2 = expectation(description: "image download should succeed")
 
-        let requestReceipt2 = downloader.downloadImage(urlRequest: download) { closureResponse in
+        let requestReceipt2 = downloader.download(urlRequest) { closureResponse in
             result2 = closureResponse.result
             expectation2.fulfill()
         }
@@ -795,7 +795,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatFilteredImageIsStoredInCacheIfCacheIsAvailable() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let size  = CGSize(width: 20, height: 20)
         let filter = ScaledToSizeFilter(size: size)
 
@@ -805,7 +805,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         var result2: Result<Image, NSError>?
 
         // When
-        let requestReceipt1 = downloader.downloadImage(urlRequest: download, filter: filter) { closureResponse in
+        let requestReceipt1 = downloader.download(urlRequest, filter: filter) { closureResponse in
             result1 = closureResponse.result
             expectation1.fulfill()
         }
@@ -814,7 +814,7 @@ class ImageDownloaderTestCase: BaseTestCase {
 
         let expectation2 = expectation(description: "image download should succeed")
 
-        let requestReceipt2 = downloader.downloadImage(urlRequest: download, filter: filter) { closureResponse in
+        let requestReceipt2 = downloader.download(urlRequest, filter: filter) { closureResponse in
             result2 = closureResponse.result
             expectation2.fulfill()
         }
@@ -847,12 +847,12 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatStartingRequestIncrementsActiveRequestCount() {
         // Given
         let downloader = ImageDownloader()
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
-        let request = downloader.sessionManager.request(download)
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let request = downloader.sessionManager.request(urlRequest)
 
         // When
         let activeRequestCountBefore = downloader.activeRequestCount
-        downloader.startRequest(request)
+        downloader.start(request)
         let activeRequestCountAfter = downloader.activeRequestCount
 
         request.cancel()
@@ -866,15 +866,15 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
-        let download2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
+        let urlRequest1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
 
-        let request1 = downloader.sessionManager.request(download1)
-        let request2 = downloader.sessionManager.request(download2)
+        let request1 = downloader.sessionManager.request(urlRequest1)
+        let request2 = downloader.sessionManager.request(urlRequest2)
 
         // When
-        downloader.enqueueRequest(request1)
-        downloader.enqueueRequest(request2)
+        downloader.enqueue(request1)
+        downloader.enqueue(request2)
 
         let queuedRequests = downloader.queuedRequests
 
@@ -888,15 +888,15 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader(downloadPrioritization: .lifo)
 
-        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
-        let download2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
+        let urlRequest1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
 
-        let request1 = downloader.sessionManager.request(download1)
-        let request2 = downloader.sessionManager.request(download2)
+        let request1 = downloader.sessionManager.request(urlRequest1)
+        let request2 = downloader.sessionManager.request(urlRequest2)
 
         // When
-        downloader.enqueueRequest(request1)
-        downloader.enqueueRequest(request2)
+        downloader.enqueue(request1)
+        downloader.enqueue(request2)
 
         let queuedRequests = downloader.queuedRequests
 
@@ -910,16 +910,16 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader(downloadPrioritization: .fifo)
 
-        let download1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
-        let download2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
+        let urlRequest1 = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest2 = URLRequest(urlString: "https://httpbin.org/image/png", method: .get)
 
-        let request1 = downloader.sessionManager.request(download1)
-        let request2 = downloader.sessionManager.request(download2)
+        let request1 = downloader.sessionManager.request(urlRequest1)
+        let request2 = downloader.sessionManager.request(urlRequest2)
 
         // When
-        downloader.enqueueRequest(request1)
-        downloader.enqueueRequest(request2)
-        downloader.dequeueRequest()
+        downloader.enqueue(request1)
+        downloader.enqueue(request2)
+        downloader.dequeue()
 
         let queuedRequests = downloader.queuedRequests
 

--- a/Tests/ImageFilterTests.swift
+++ b/Tests/ImageFilterTests.swift
@@ -97,16 +97,16 @@ class ImageFilterTestCase: BaseTestCase {
 
     func testThatDynamicImageFilterReturnsCorrectFilteredImage() {
         // Given
-        let image = imageForResource("pirate", withExtension: "jpg")
+        let image = self.image(forResource: "pirate", withExtension: "jpg")
         let filter = DynamicImageFilter("DynamicScaleToSizeFilter") { image in
-            return image.af_imageScaledToSize(CGSize(width: 50.0, height: 50.0))
+            return image.af_imageScaledTo(CGSize(width: 50.0, height: 50.0))
         }
 
         // When
         let filteredImage = filter.filter(image)
 
         // Then
-        let expectedFilteredImage = imageForResource("pirate-scaled-50x50-@\(scale)x", withExtension: "png")
+        let expectedFilteredImage = self.image(forResource: "pirate-scaled-50x50-@\(scale)x", withExtension: "png")
         XCTAssertTrue(filteredImage.af_isEqualToImage(expectedFilteredImage), "filtered image pixels do not match")
     }
 
@@ -114,7 +114,7 @@ class ImageFilterTestCase: BaseTestCase {
 
     func testThatDynamicCompositeImageFilterReturnsCorrectFilteredImage() {
         // Given
-        let image = imageForResource("pirate", withExtension: "jpg")
+        let image = self.image(forResource: "pirate", withExtension: "jpg")
         let filter = DynamicCompositeImageFilter(
             ScaledToSizeFilter(size: largeSquareSize),
             RoundedCornersFilter(radius: 20)
@@ -124,8 +124,8 @@ class ImageFilterTestCase: BaseTestCase {
         let filteredImage = filter.filter(image)
 
         // Then
-        let expectedFilteredImage = imageForResource(
-            "pirate-scaled.to.size.with.rounded.corners-100x100x20-@\(scale)x",
+        let expectedFilteredImage = self.image(
+            forResource: "pirate-scaled.to.size.with.rounded.corners-100x100x20-@\(scale)x",
             withExtension: "png"
         )
 
@@ -136,53 +136,53 @@ class ImageFilterTestCase: BaseTestCase {
 
     func testThatScaledToSizeFilterReturnsCorrectFilteredImage() {
         // Given
-        let image = imageForResource("pirate", withExtension: "jpg")
+        let image = self.image(forResource: "pirate", withExtension: "jpg")
         let filter = ScaledToSizeFilter(size: squareSize)
 
         // When
         let filteredImage = filter.filter(image)
 
         // Then
-        let expectedFilteredImage = imageForResource("pirate-scaled-50x50-@\(scale)x", withExtension: "png")
+        let expectedFilteredImage = self.image(forResource: "pirate-scaled-50x50-@\(scale)x", withExtension: "png")
         XCTAssertTrue(filteredImage.af_isEqualToImage(expectedFilteredImage), "filtered image pixels do not match")
     }
 
     func testThatAspectScaledToFitSizeFilterReturnsCorrectFilteredImage() {
         // Given
-        let image = imageForResource("pirate", withExtension: "jpg")
+        let image = self.image(forResource: "pirate", withExtension: "jpg")
         let filter = AspectScaledToFitSizeFilter(size: squareSize)
 
         // When
         let filteredImage = filter.filter(image)
 
         // Then
-        let expectedFilteredImage = imageForResource("pirate-aspect.scaled.to.fit-50x50-@\(scale)x", withExtension: "png")
+        let expectedFilteredImage = self.image(forResource: "pirate-aspect.scaled.to.fit-50x50-@\(scale)x", withExtension: "png")
         XCTAssertTrue(filteredImage.af_isEqualToImage(expectedFilteredImage), "filtered image pixels do not match")
     }
 
     func testThatAspectScaledToFillSizeFilterReturnsCorrectFilteredImage() {
         // Given
-        let image = imageForResource("pirate", withExtension: "jpg")
+        let image = self.image(forResource: "pirate", withExtension: "jpg")
         let filter = AspectScaledToFillSizeFilter(size: squareSize)
 
         // When
         let filteredImage = filter.filter(image)
 
         // Then
-        let expectedFilteredImage = imageForResource("pirate-aspect.scaled.to.fill-50x50-@\(scale)x", withExtension: "png")
+        let expectedFilteredImage = self.image(forResource: "pirate-aspect.scaled.to.fill-50x50-@\(scale)x", withExtension: "png")
         XCTAssertTrue(filteredImage.af_isEqualToImage(expectedFilteredImage), "filtered image pixels do not match")
     }
 
     func testThatRoundedCornersFilterReturnsCorrectFilteredImage() {
         // Given
-        let image = imageForResource("pirate", withExtension: "jpg")
+        let image = self.image(forResource: "pirate", withExtension: "jpg")
         let filter = RoundedCornersFilter(radius: 20, divideRadiusByImageScale: true)
 
         // When
         let filteredImage = filter.filter(image)
 
         // Then
-        let expectedFilteredImage = imageForResource("pirate-radius-20", withExtension: "png")
+        let expectedFilteredImage = self.image(forResource: "pirate-radius-20", withExtension: "png")
         XCTAssertTrue(filteredImage.af_isEqualToImage(expectedFilteredImage), "filtered image pixels do not match")
 
         let expectedIdentifier = "RoundedCornersFilter-radius:(20)-divided:(true)"
@@ -191,27 +191,27 @@ class ImageFilterTestCase: BaseTestCase {
 
     func testThatCircleFilterReturnsCorrectFilteredImage() {
         // Given
-        let image = imageForResource("pirate", withExtension: "jpg")
+        let image = self.image(forResource: "pirate", withExtension: "jpg")
         let filter = CircleFilter()
 
         // When
         let filteredImage = filter.filter(image)
 
         // Then
-        let expectedFilteredImage = imageForResource("pirate-circle", withExtension: "png")
+        let expectedFilteredImage = self.image(forResource: "pirate-circle", withExtension: "png")
         XCTAssertTrue(filteredImage.af_isEqualToImage(expectedFilteredImage), "filtered image pixels do not match")
     }
 
     func testThatBlurFilterReturnsCorrectFilteredImage() {
         // Given
-        let image = imageForResource("unicorn", withExtension: "png")
+        let image = self.image(forResource: "unicorn", withExtension: "png")
         let filter = BlurFilter(blurRadius: 8)
 
         // When
         let filteredImage = filter.filter(image)
 
         // Then
-        let expectedFilteredImage = imageForResource("unicorn-blurred-8", withExtension: "png")
+        let expectedFilteredImage = self.image(forResource: "unicorn-blurred-8", withExtension: "png")
         let pixelsMatch = filteredImage.af_isEqualToImage(expectedFilteredImage)
 
         XCTAssertTrue(pixelsMatch, "pixels match should be true")
@@ -221,15 +221,15 @@ class ImageFilterTestCase: BaseTestCase {
 
     func testThatScaledToSizeWithRoundedCornersFilterReturnsCorrectFilteredImage() {
         // Given
-        let image = imageForResource("pirate", withExtension: "jpg")
+        let image = self.image(forResource: "pirate", withExtension: "jpg")
         let filter = ScaledToSizeWithRoundedCornersFilter(size: largeSquareSize, radius: 20)
 
         // When
         let filteredImage = filter.filter(image)
 
         // Then
-        let expectedFilteredImage = imageForResource(
-            "pirate-scaled.to.size.with.rounded.corners-100x100x20-@\(scale)x",
+        let expectedFilteredImage = self.image(
+            forResource: "pirate-scaled.to.size.with.rounded.corners-100x100x20-@\(scale)x",
             withExtension: "png"
         )
 
@@ -238,15 +238,15 @@ class ImageFilterTestCase: BaseTestCase {
 
     func testThatAspectScaledToFillSizeWithRoundedCornersFilterReturnsCorrectFilteredImage() {
         // Given
-        let image = imageForResource("pirate", withExtension: "jpg")
+        let image = self.image(forResource: "pirate", withExtension: "jpg")
         let filter = AspectScaledToFillSizeWithRoundedCornersFilter(size: largeSquareSize, radius: 20)
 
         // When
         let filteredImage = filter.filter(image)
 
         // Then
-        let expectedFilteredImage = imageForResource(
-            "pirate-aspect.scaled.to.fill.size.with.rounded.corners-100x100x20-@\(scale)x",
+        let expectedFilteredImage = self.image(
+            forResource: "pirate-aspect.scaled.to.fill.size.with.rounded.corners-100x100x20-@\(scale)x",
             withExtension: "png"
         )
 
@@ -255,15 +255,15 @@ class ImageFilterTestCase: BaseTestCase {
 
     func testThatScaledToSizeCircleFilterReturnsCorrectFilteredImage() {
         // Given
-        let image = imageForResource("pirate", withExtension: "jpg")
+        let image = self.image(forResource: "pirate", withExtension: "jpg")
         let filter = ScaledToSizeCircleFilter(size: largeSquareSize)
 
         // When
         let filteredImage = filter.filter(image)
 
         // Then
-        let expectedFilteredImage = imageForResource(
-            "pirate-scaled.to.size.circle-100x100-@\(scale)x",
+        let expectedFilteredImage = self.image(
+            forResource: "pirate-scaled.to.size.circle-100x100-@\(scale)x",
             withExtension: "png"
         )
 
@@ -272,15 +272,15 @@ class ImageFilterTestCase: BaseTestCase {
 
     func testThatAspectScaledToFillSizeCircleFilterReturnsCorrectFilteredImage() {
         // Given
-        let image = imageForResource("pirate", withExtension: "jpg")
+        let image = self.image(forResource: "pirate", withExtension: "jpg")
         let filter = AspectScaledToFillSizeCircleFilter(size: largeSquareSize)
 
         // When
         let filteredImage = filter.filter(image)
 
         // Then
-        let expectedFilteredImage = imageForResource(
-            "pirate-aspect.scaled.to.fill.size.circle-100x100-@\(scale)x",
+        let expectedFilteredImage = self.image(
+            forResource: "pirate-aspect.scaled.to.fill.size.circle-100x100-@\(scale)x",
             withExtension: "png"
         )
 

--- a/Tests/ImageFilterTests.swift
+++ b/Tests/ImageFilterTests.swift
@@ -99,7 +99,7 @@ class ImageFilterTestCase: BaseTestCase {
         // Given
         let image = self.image(forResource: "pirate", withExtension: "jpg")
         let filter = DynamicImageFilter("DynamicScaleToSizeFilter") { image in
-            return image.af_imageScaledTo(CGSize(width: 50.0, height: 50.0))
+            return image.af_imageScaled(to: CGSize(width: 50.0, height: 50.0))
         }
 
         // When

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -134,7 +134,7 @@ class RequestTestCase: BaseTestCase {
 
     func testThatImageResponseSerializerCanDownloadImageFromFileURL() {
         // Given
-        let url = urlForResource("apple", withExtension: "jpg")
+        let url = self.url(forResource: "apple", withExtension: "jpg")
         let expectation = self.expectation(description: "Request should return JPG response image")
 
         var response: Response<Image, NSError>?

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -62,13 +62,13 @@ class RequestTestCase: BaseTestCase {
 
     func testThatImageResponseSerializerCanDownloadPNGImage() {
         // Given
-        let URLString = "https://httpbin.org/image/png"
+        let urlString = "https://httpbin.org/image/png"
         let expectation = self.expectation(description: "Request should return PNG response image")
 
         var response: Response<Image, NSError>?
 
         // When
-        manager.request(.GET, URLString)
+        sessionManager.request(urlString, withMethod: .get)
             .responseImage { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -98,13 +98,13 @@ class RequestTestCase: BaseTestCase {
 
     func testThatImageResponseSerializerCanDownloadJPGImage() {
         // Given
-        let URLString = "https://httpbin.org/image/jpeg"
+        let urlString = "https://httpbin.org/image/jpeg"
         let expectation = self.expectation(description: "Request should return JPG response image")
 
         var response: Response<Image, NSError>?
 
         // When
-        manager.request(.GET, URLString)
+        sessionManager.request(urlString, withMethod: .get)
             .responseImage { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -134,13 +134,13 @@ class RequestTestCase: BaseTestCase {
 
     func testThatImageResponseSerializerCanDownloadImageFromFileURL() {
         // Given
-        let URL = URLForResource("apple", withExtension: "jpg")
+        let url = urlForResource("apple", withExtension: "jpg")
         let expectation = self.expectation(description: "Request should return JPG response image")
 
         var response: Response<Image, NSError>?
 
         // When
-        manager.request(.GET, URL)
+        sessionManager.request(url, withMethod: .get)
             .responseImage { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -174,13 +174,13 @@ class RequestTestCase: BaseTestCase {
 
     func testThatImageResponseSerializerCanDownloadAndInflatePNGImage() {
         // Given
-        let URLString = "https://httpbin.org/image/png"
+        let urlString = "https://httpbin.org/image/png"
         let expectation = self.expectation(description: "Request should return PNG response image")
 
         var response: Response<Image, NSError>?
 
         // When
-        manager.request(.GET, URLString)
+        sessionManager.request(urlString, withMethod: .get)
             .responseImage { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -206,13 +206,13 @@ class RequestTestCase: BaseTestCase {
 
     func testThatImageResponseSerializerCanDownloadAndInflateJPGImage() {
         // Given
-        let URLString = "https://httpbin.org/image/jpeg"
+        let urlString = "https://httpbin.org/image/jpeg"
         let expectation = self.expectation(description: "Request should return JPG response image")
 
         var response: Response<Image, NSError>?
 
         // When
-        manager.request(.GET, URLString)
+        sessionManager.request(urlString, withMethod: .get)
             .responseImage { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -242,13 +242,13 @@ class RequestTestCase: BaseTestCase {
 
     func testThatAttemptingToDownloadImageFromBadURLReturnsFailureResult() {
         // Given
-        let URLString = "https://invalid.for.sure"
+        let urlString = "https://invalid.for.sure"
         let expectation = self.expectation(description: "Request should fail with bad URL")
 
         var response: Response<Image, NSError>?
 
         // When
-        manager.request(.GET, URLString)
+        sessionManager.request(urlString, withMethod: .get)
             .responseImage { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -265,13 +265,13 @@ class RequestTestCase: BaseTestCase {
 
     func testThatAttemptingToDownloadUnsupportedImageTypeReturnsFailureResult() {
         // Given
-        let URLString = "https://httpbin.org/image/webp"
+        let urlString = "https://httpbin.org/image/webp"
         let expectation = self.expectation(description: "Request should return webp response image")
 
         var response: Response<Image, NSError>?
 
         // When
-        manager.request(.GET, URLString)
+        sessionManager.request(urlString, withMethod: .get)
             .responseImage { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -293,13 +293,13 @@ class RequestTestCase: BaseTestCase {
 
     func testThatAttemptingToSerializeEmptyDataReturnsFailureResult() {
         // Given
-        let URLString = "https://httpbin.org/bytes/0"
+        let urlString = "https://httpbin.org/bytes/0"
         let expectation = self.expectation(description: "Request should download no bytes")
 
         var response: Response<Image, NSError>?
 
         // When
-        manager.request(.GET, URLString)
+        sessionManager.request(urlString, withMethod: .get)
             .responseImage { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -322,13 +322,13 @@ class RequestTestCase: BaseTestCase {
     func testThatAttemptingToSerializeRandomStreamDataReturnsFailureResult() {
         // Given
         let randomBytes = 4 * 1024 * 1024
-        let URLString = "https://httpbin.org/bytes/\(randomBytes)"
+        let urlString = "https://httpbin.org/bytes/\(randomBytes)"
         let expectation = self.expectation(description: "Request should download random bytes")
 
         var response: Response<Image, NSError>?
 
         // When
-        manager.request(.GET, URLString)
+        sessionManager.request(urlString, withMethod: .get)
             .responseImage { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
@@ -350,17 +350,17 @@ class RequestTestCase: BaseTestCase {
 
     func testThatAttemptingToSerializeJSONResponseIntoImageReturnsFailureResult() {
         // Given
-        let URLString = "https://httpbin.org/get"
+        let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "Request should return JSON")
 
         var response: Response<Image, NSError>?
 
         // When
-        manager.request(.GET, URLString)
+        sessionManager.request(urlString, withMethod: .get)
             .responseImage { closureResponse in
                 response = closureResponse
                 expectation.fulfill()
-        }
+            }
 
         waitForExpectations(timeout: timeout, handler: nil)
 

--- a/Tests/UIButtonTests.swift
+++ b/Tests/UIButtonTests.swift
@@ -352,7 +352,7 @@ class UIButtonTests: BaseTestCase {
         let button = UIButton()
 
         let downloader = ImageDownloader.defaultInstance
-        let download = URLRequest(.GET, url.absoluteString)
+        let download = URLRequest(urlString: url.absoluteString, method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         downloader.downloadImage(urlRequest: download) { _ in
@@ -447,7 +447,7 @@ class UIButtonTests: BaseTestCase {
         let button = UIButton()
 
         let downloader = ImageDownloader.defaultInstance
-        let download = URLRequest(.GET, url.absoluteString)
+        let download = URLRequest(urlString: url.absoluteString, method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         downloader.downloadImage(urlRequest: download) { _ in
@@ -470,7 +470,7 @@ class UIButtonTests: BaseTestCase {
         let button = UIButton()
 
         let downloader = ImageDownloader.defaultInstance
-        let download = URLRequest(.GET, url.absoluteString)
+        let download = URLRequest(urlString: url.absoluteString, method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         downloader.downloadImage(urlRequest: download) { _ in

--- a/Tests/UIButtonTests.swift
+++ b/Tests/UIButtonTests.swift
@@ -53,7 +53,7 @@ private class TestButton: UIButton {
 // MARK: -
 
 class UIButtonTests: BaseTestCase {
-    let url = Foundation.URL(string: "https://httpbin.org/image/jpeg")!
+    let url = URL(string: "https://httpbin.org/image/jpeg")!
 
     // MARK: - Setup and Teardown
 
@@ -61,8 +61,8 @@ class UIButtonTests: BaseTestCase {
         super.setUp()
 
         ImageDownloader.defaultURLCache().removeAllCachedResponses()
-        ImageDownloader.defaultInstance.imageCache?.removeAllImages()
-        UIButton.af_sharedImageDownloader = ImageDownloader.defaultInstance
+        ImageDownloader.default.imageCache?.removeAllImages()
+        UIButton.af_sharedImageDownloader = ImageDownloader.default
     }
 
     // MARK: - Image Download
@@ -78,7 +78,7 @@ class UIButtonTests: BaseTestCase {
         }
 
         // When
-        button.af_setImageForState([], url: url)
+        button.af_setImage(for: [], url: url)
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -96,7 +96,7 @@ class UIButtonTests: BaseTestCase {
         }
 
         // When
-        button.af_setBackgroundImageForState([], url: url)
+        button.af_setBackgroundImage(for: [], url: url)
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -110,15 +110,17 @@ class UIButtonTests: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        button.af_setImageForState([], url: url)
-        button.af_cancelImageRequestForState([])
-        button.af_setImageForState(
-            [],
+        button.af_setImage(for: [], url: url)
+        button.af_cancelImageRequest(for: [])
+        button.af_setImage(
+            for: [],
             urlRequest: URLRequest(url: url),
-            placeholderImage: nil) { response in
+            placeholderImage: nil,
+            completion: { response in
                 result = response.result
                 expectation.fulfill()
-        }
+            }
+        )
 
         // Then
         waitForExpectations(timeout: timeout, handler: nil)
@@ -132,15 +134,17 @@ class UIButtonTests: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        button.af_setBackgroundImageForState([], url: url)
-        button.af_cancelBackgroundImageRequestForState([])
-        button.af_setBackgroundImageForState(
-            [],
+        button.af_setBackgroundImage(for: [], url: url)
+        button.af_cancelBackgroundImageRequest(for: [])
+        button.af_setBackgroundImage(
+            for: [],
             urlRequest: URLRequest(url: url),
-            placeholderImage: nil) { response in
+            placeholderImage: nil,
+            completion: { response in
                 result = response.result
                 expectation.fulfill()
-        }
+            }
+        )
 
         waitForExpectations(timeout: timeout, handler: nil)
 
@@ -159,12 +163,12 @@ class UIButtonTests: BaseTestCase {
         }
 
         // When
-        button.af_setImageForState([], url: url)
+        button.af_setImage(for: [], url: url)
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertTrue(imageDownloadComplete)
-        XCTAssertNil(button.backgroundImageRequestReceiptForState([]))
+        XCTAssertNil(button.backgroundImageRequestReceipt(for: []))
     }
 
     func testThatActiveBackgroundImageRequestReceiptIsNilAfterImageDownloadCompletes() {
@@ -178,23 +182,23 @@ class UIButtonTests: BaseTestCase {
         }
 
         // When
-        button.af_setBackgroundImageForState([], url: url)
+        button.af_setBackgroundImage(for: [], url: url)
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertTrue(backgroundImageDownloadComplete)
-        XCTAssertNil(button.backgroundImageRequestReceiptForState([]))
+        XCTAssertNil(button.backgroundImageRequestReceipt(for: []))
     }
 
     func testThatMultipleImageRequestReceiptStatesCanBeDownloadedInParallel() {
         // Given
         let button = TestButton()
-        var _url = url
+        var url = self.url
 
         // When
         let expectation1 = expectation(description: "background image should download successfully")
         var normalStateImageDownloadComplete = false
-        button.af_setImageForState([], url: _url)
+        button.af_setImage(for: [], url: url)
         button.imageObserver = {
             normalStateImageDownloadComplete = true
             expectation1.fulfill()
@@ -204,9 +208,9 @@ class UIButtonTests: BaseTestCase {
 
         let expectation2 = expectation(description: "background image should download successfully")
         var selectedStateImageDownloadComplete = false
-        _url = Foundation.URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
+        url = URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
 
-        button.af_setImageForState([.selected], url: _url)
+        button.af_setImage(for: [.selected], url: url)
         button.imageObserver = {
             selectedStateImageDownloadComplete = true
             expectation2.fulfill()
@@ -216,9 +220,9 @@ class UIButtonTests: BaseTestCase {
 
         let expectation3 = expectation(description: "background image should download successfully")
         var highlightedStateImageDownloadComplete = false
-        _url = Foundation.URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
+        url = URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
 
-        button.af_setImageForState([.highlighted], url: _url)
+        button.af_setImage(for: [.highlighted], url: url)
         button.imageObserver = {
             highlightedStateImageDownloadComplete = true
             expectation3.fulfill()
@@ -228,9 +232,9 @@ class UIButtonTests: BaseTestCase {
 
         let expectation4 = expectation(description: "background image should download successfully")
         var disabledStateImageDownloadComplete = false
-        _url = Foundation.URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
+        url = URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
 
-        button.af_setImageForState([.disabled], url: _url)
+        button.af_setImage(for: [.disabled], url: url)
         button.imageObserver = {
             disabledStateImageDownloadComplete = true
             expectation4.fulfill()
@@ -255,12 +259,12 @@ class UIButtonTests: BaseTestCase {
     func testThatMultipleBackgroundImageRequestReceiptStatesCanBeDownloadedInParallel() {
         // Given
         let button = TestButton()
-        var _url = url
+        var url = self.url
 
         // When
         let expectation1 = expectation(description: "background image should download successfully")
         var normalStateBackgroundImageDownloadComplete = false
-        button.af_setBackgroundImageForState([], url: _url)
+        button.af_setBackgroundImage(for: [], url: url)
         button.imageObserver = {
             normalStateBackgroundImageDownloadComplete = true
             expectation1.fulfill()
@@ -269,9 +273,9 @@ class UIButtonTests: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
         let expectation2 = expectation(description: "background image should download successfully")
         var selectedStateBackgroundImageDownloadComplete = false
-        _url = Foundation.URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
+        url = URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
 
-        button.af_setBackgroundImageForState([.selected], url: _url)
+        button.af_setBackgroundImage(for: [.selected], url: url)
         button.imageObserver = {
             selectedStateBackgroundImageDownloadComplete = true
             expectation2.fulfill()
@@ -281,9 +285,9 @@ class UIButtonTests: BaseTestCase {
 
         let expectation3 = expectation(description: "background image should download successfully")
         var highlightedStateBackgroundImageDownloadComplete = false
-        _url = Foundation.URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
+        url = URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
 
-        button.af_setBackgroundImageForState([.highlighted], url: _url)
+        button.af_setBackgroundImage(for: [.highlighted], url: url)
         button.imageObserver = {
             highlightedStateBackgroundImageDownloadComplete = true
             expectation3.fulfill()
@@ -293,9 +297,9 @@ class UIButtonTests: BaseTestCase {
 
         let expectation4 = expectation(description: "background image should download successfully")
         var disabledStateBackgroundImageDownloadComplete = false
-        _url = Foundation.URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
+        url = URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
 
-        button.af_setBackgroundImageForState([.disabled], url: _url)
+        button.af_setBackgroundImage(for: [.disabled], url: url)
         button.imageObserver = {
             disabledStateBackgroundImageDownloadComplete = true
             expectation4.fulfill()
@@ -334,14 +338,14 @@ class UIButtonTests: BaseTestCase {
         button.af_imageDownloader = imageDownloader
 
         // When
-        button.af_setImageForState([], url: url)
+        button.af_setImage(for: [], url: url)
         let activeRequestCount = imageDownloader.activeRequestCount
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertTrue(imageDownloadComplete)
-        XCTAssertNil(button.imageRequestReceiptForState([]), "active request receipt should be nil after download completes")
+        XCTAssertNil(button.imageRequestReceipt(for: []), "active request receipt should be nil after download completes")
         XCTAssertEqual(activeRequestCount, 1, "active request count should be 1")
     }
 
@@ -351,19 +355,19 @@ class UIButtonTests: BaseTestCase {
         // Given
         let button = UIButton()
 
-        let downloader = ImageDownloader.defaultInstance
-        let download = URLRequest(urlString: url.absoluteString, method: .get)
+        let downloader = ImageDownloader.default
+        let urlRequest = URLRequest(urlString: url.absoluteString, method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
-        downloader.downloadImage(urlRequest: download) { _ in
+        downloader.download(urlRequest) { _ in
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // When
-        button.af_setImageForState([], url: url)
-        button.af_cancelImageRequestForState([])
+        button.af_setImage(for: [], url: url)
+        button.af_cancelImageRequest(for: [])
 
         // Then
         XCTAssertNotNil(button.image(for: UIControlState()), "button image should not be nil")
@@ -387,7 +391,7 @@ class UIButtonTests: BaseTestCase {
 
     func testThatPlaceholderImageIsDisplayedUntilImageIsDownloadedFromURL() {
         // Given
-        let placeholderImage = imageForResource("pirate", withExtension: "jpg")
+        let placeholderImage = image(forResource: "pirate", withExtension: "jpg")
         let expectation = self.expectation(description: "image should download successfully")
 
         var imageDownloadComplete = false
@@ -396,7 +400,7 @@ class UIButtonTests: BaseTestCase {
         let button = TestButton ()
 
         // When
-        button.af_setImageForState([], url: url, placeHolderImage: placeholderImage)
+        button.af_setImage(for: [], url: url, placeHolderImage: placeholderImage)
         let initialImageEqualsPlaceholderImage = button.image(for:[]) === placeholderImage
 
         button.imageObserver = {
@@ -415,7 +419,7 @@ class UIButtonTests: BaseTestCase {
 
     func testThatBackgroundPlaceholderImageIsDisplayedUntilImageIsDownloadedFromURL() {
         // Given
-        let placeholderImage = imageForResource("pirate", withExtension: "jpg")
+        let placeholderImage = image(forResource: "pirate", withExtension: "jpg")
         let expectation = self.expectation(description: "image should download successfully")
 
         var backgroundImageDownloadComplete = false
@@ -424,7 +428,7 @@ class UIButtonTests: BaseTestCase {
         let button = TestButton ()
 
         // When
-        button.af_setBackgroundImageForState([], url: url, placeHolderImage: placeholderImage)
+        button.af_setBackgroundImage(for: [], url: url, placeHolderImage: placeholderImage)
         let initialImageEqualsPlaceholderImage = button.backgroundImage(for:[]) === placeholderImage
 
         button.imageObserver = {
@@ -443,21 +447,21 @@ class UIButtonTests: BaseTestCase {
 
     func testThatImagePlaceholderIsNeverDisplayedIfCachedImageIsAvailable() {
         // Given
-        let placeholderImage = imageForResource("pirate", withExtension: "jpg")
+        let placeholderImage = image(forResource: "pirate", withExtension: "jpg")
         let button = UIButton()
 
-        let downloader = ImageDownloader.defaultInstance
-        let download = URLRequest(urlString: url.absoluteString, method: .get)
+        let downloader = ImageDownloader.default
+        let urlRequest = URLRequest(urlString: url.absoluteString, method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
-        downloader.downloadImage(urlRequest: download) { _ in
+        downloader.download(urlRequest) { _ in
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // When
-        button.af_setImageForState([], url: url, placeHolderImage: placeholderImage)
+        button.af_setImage(for: [], url: url, placeHolderImage: placeholderImage)
 
         // Then
         XCTAssertNotNil(button.image(for: UIControlState()), "button image should not be nil")
@@ -466,21 +470,21 @@ class UIButtonTests: BaseTestCase {
 
     func testThatBackgroundPlaceholderIsNeverDisplayedIfCachedImageIsAvailable() {
         // Given
-        let placeholderImage = imageForResource("pirate", withExtension: "jpg")
+        let placeholderImage = image(forResource: "pirate", withExtension: "jpg")
         let button = UIButton()
 
-        let downloader = ImageDownloader.defaultInstance
-        let download = URLRequest(urlString: url.absoluteString, method: .get)
+        let downloader = ImageDownloader.default
+        let urlRequest = URLRequest(urlString: url.absoluteString, method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
-        downloader.downloadImage(urlRequest: download) { _ in
+        downloader.download(urlRequest) { _ in
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // When
-        button.af_setBackgroundImageForState([], url: url, placeHolderImage: placeholderImage)
+        button.af_setBackgroundImage(for: [], url: url, placeHolderImage: placeholderImage)
 
         // Then
         XCTAssertNotNil(button.backgroundImage(for: UIControlState()), "button background image should not be nil")
@@ -493,7 +497,7 @@ class UIButtonTests: BaseTestCase {
         // Given
         let button = UIButton()
 
-        let urlRequest: Foundation.URLRequest = {
+        let urlRequest: URLRequest = {
             var request = URLRequest(url: url)
             request.addValue("image/*", forHTTPHeaderField: "Accept")
             return request
@@ -505,7 +509,7 @@ class UIButtonTests: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        button.af_setImageForState([], urlRequest: urlRequest, placeholderImage: nil) { response in
+        button.af_setImage(for: [], urlRequest: urlRequest, placeholderImage: nil) { response in
             completionHandlerCalled = true
             result = response.result
             expectation.fulfill()
@@ -523,7 +527,7 @@ class UIButtonTests: BaseTestCase {
         // Given
         let button = UIButton()
 
-        let urlRequest: Foundation.URLRequest = {
+        let urlRequest: URLRequest = {
             var request = URLRequest(url: url)
             request.addValue("image/*", forHTTPHeaderField: "Accept")
             return request
@@ -535,7 +539,7 @@ class UIButtonTests: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        button.af_setBackgroundImageForState([], urlRequest: urlRequest, placeholderImage: nil) { response in
+        button.af_setBackgroundImage(for: [], urlRequest: urlRequest, placeholderImage: nil) { response in
             completionHandlerCalled = true
             result = response.result
             expectation.fulfill()
@@ -552,7 +556,7 @@ class UIButtonTests: BaseTestCase {
     func testThatCompletionHandlerIsCalledWhenImageDownloadFails() {
         // Given
         let button = UIButton()
-        let urlRequest = Foundation.URLRequest(url: Foundation.URL(string: "really-bad-domain")!)
+        let urlRequest = URLRequest(url: URL(string: "really-bad-domain")!)
 
         let expectation = self.expectation(description: "image download should succeed")
 
@@ -560,7 +564,7 @@ class UIButtonTests: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        button.af_setImageForState([], urlRequest: urlRequest, placeholderImage: nil) { response in
+        button.af_setImage(for: [], urlRequest: urlRequest, placeholderImage: nil) { response in
             completionHandlerCalled = true
             result = response.result
             expectation.fulfill()
@@ -577,7 +581,7 @@ class UIButtonTests: BaseTestCase {
     func testThatCompletionHandlerIsCalledWhenBackgroundImageDownloadFails() {
         // Given
         let button = UIButton()
-        let urlRequest = Foundation.URLRequest(url: Foundation.URL(string: "really-bad-domain")!)
+        let urlRequest = URLRequest(url: URL(string: "really-bad-domain")!)
 
         let expectation = self.expectation(description: "image download should succeed")
 
@@ -585,7 +589,7 @@ class UIButtonTests: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        button.af_setBackgroundImageForState([], urlRequest: urlRequest, placeholderImage: nil) { response in
+        button.af_setBackgroundImage(for: [], urlRequest: urlRequest, placeholderImage: nil) { response in
             completionHandlerCalled = true
             result = response.result
             expectation.fulfill()
@@ -604,7 +608,7 @@ class UIButtonTests: BaseTestCase {
     func testThatImageDownloadCanBeCancelled() {
         // Given
         let button = UIButton()
-        let urlRequest = Foundation.URLRequest(url: Foundation.URL(string: "domain-name-does-not-exist")!)
+        let urlRequest = URLRequest(url: URL(string: "domain-name-does-not-exist")!)
 
         let expectation = self.expectation(description: "image download should succeed")
 
@@ -612,8 +616,8 @@ class UIButtonTests: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        button.af_setImageForState(
-            [],
+        button.af_setImage(
+            for: [],
             urlRequest: urlRequest,
             placeholderImage: nil,
             completion: { closureResponse in
@@ -623,7 +627,7 @@ class UIButtonTests: BaseTestCase {
             }
         )
 
-        button.af_cancelImageRequestForState([])
+        button.af_cancelImageRequest(for: [])
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -635,7 +639,7 @@ class UIButtonTests: BaseTestCase {
     func testThatBackgroundImageDownloadCanBeCancelled() {
         // Given
         let button = UIButton()
-        let urlRequest = Foundation.URLRequest(url: Foundation.URL(string: "domain-name-does-not-exist")!)
+        let urlRequest = URLRequest(url: URL(string: "domain-name-does-not-exist")!)
 
         let expectation = self.expectation(description: "background image download should succeed")
 
@@ -643,8 +647,8 @@ class UIButtonTests: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        button.af_setBackgroundImageForState(
-            [],
+        button.af_setBackgroundImage(
+            for: [],
             urlRequest: urlRequest,
             placeholderImage: nil,
             completion: { closureResponse in
@@ -654,7 +658,7 @@ class UIButtonTests: BaseTestCase {
             }
         )
 
-        button.af_cancelBackgroundImageRequestForState([])
+        button.af_cancelBackgroundImageRequest(for: [])
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -673,8 +677,8 @@ class UIButtonTests: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        button.af_setImageForState(
-            [],
+        button.af_setImage(
+            for: [],
             urlRequest: URLRequest(url: url),
             placeholderImage: nil,
             completion: { closureResponse in
@@ -682,9 +686,9 @@ class UIButtonTests: BaseTestCase {
             }
         )
 
-        button.af_setImageForState(
-            [],
-            urlRequest: URLRequest(url: Foundation.URL(string: "https://httpbin.org/image/png")!),
+        button.af_setImage(
+            for: [],
+            urlRequest: URLRequest(url: URL(string: "https://httpbin.org/image/png")!),
             placeholderImage: nil,
             completion: { closureResponse in
                 completion2Called = true
@@ -712,8 +716,8 @@ class UIButtonTests: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        button.af_setBackgroundImageForState(
-            [],
+        button.af_setBackgroundImage(
+            for: [],
             urlRequest: URLRequest(url: url),
             placeholderImage: nil,
             completion: { closureResponse in
@@ -721,9 +725,9 @@ class UIButtonTests: BaseTestCase {
             }
         )
 
-        button.af_setBackgroundImageForState(
-            [],
-            urlRequest: URLRequest(url: Foundation.URL(string: "https://httpbin.org/image/png")!),
+        button.af_setBackgroundImage(
+            for: [],
+            urlRequest: URLRequest(url: URL(string: "https://httpbin.org/image/png")!),
             placeholderImage: nil,
             completion: { closureResponse in
                 completion2Called = true
@@ -751,8 +755,8 @@ class UIButtonTests: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        button.af_setImageForState(
-            [],
+        button.af_setImage(
+            for: [],
             urlRequest: URLRequest(url: url),
             placeholderImage: nil,
             completion: { closureResponse in
@@ -760,10 +764,10 @@ class UIButtonTests: BaseTestCase {
             }
         )
 
-        button.af_cancelImageRequestForState([])
+        button.af_cancelImageRequest(for: [])
 
-        button.af_setImageForState(
-            [],
+        button.af_setImage(
+            for: [],
             urlRequest: URLRequest(url: url),
             placeholderImage: nil,
             completion: { closureResponse in
@@ -792,8 +796,8 @@ class UIButtonTests: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        button.af_setBackgroundImageForState(
-            [],
+        button.af_setBackgroundImage(
+            for: [],
             urlRequest: URLRequest(url: url),
             placeholderImage: nil,
             completion: { closureResponse in
@@ -801,10 +805,10 @@ class UIButtonTests: BaseTestCase {
             }
         )
 
-        button.af_cancelBackgroundImageRequestForState([])
+        button.af_cancelBackgroundImageRequest(for: [])
 
-        button.af_setBackgroundImageForState(
-            [],
+        button.af_setBackgroundImage(
+            for: [],
             urlRequest: URLRequest(url: url),
             placeholderImage: nil,
             completion: { closureResponse in
@@ -828,7 +832,7 @@ class UIButtonTests: BaseTestCase {
     func testThatImageBehindRedirectCanBeDownloaded() {
         // Given
         let redirectURLString = "https://httpbin.org/image/png"
-        let url = Foundation.URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
+        let url = URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
 
         let expectation = self.expectation(description: "image should download successfully")
         var imageDownloadComplete = false
@@ -839,7 +843,7 @@ class UIButtonTests: BaseTestCase {
         }
 
         // When
-        button.af_setImageForState([], url: url)
+        button.af_setImage(for: [], url: url)
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -850,7 +854,7 @@ class UIButtonTests: BaseTestCase {
     func testThatBackgroundImageBehindRedirectCanBeDownloaded() {
         // Given
         let redirectURLString = "https://httpbin.org/image/png"
-        let url = Foundation.URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
+        let url = URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
 
         let expectation = self.expectation(description: "image should download successfully")
         var backgroundImageDownloadComplete = false
@@ -861,7 +865,7 @@ class UIButtonTests: BaseTestCase {
         }
 
         // When
-        button.af_setBackgroundImageForState([], url: url)
+        button.af_setBackgroundImage(for: [], url: url)
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -876,9 +880,9 @@ class UIButtonTests: BaseTestCase {
         let button = UIButton()
 
         // When
-        button.af_setImageForState([], url: url)
-        let acceptField = button.imageRequestReceiptForState([])?.request.request?.allHTTPHeaderFields?["Accept"]
-        button.af_cancelImageRequestForState([])
+        button.af_setImage(for: [], url: url)
+        let acceptField = button.imageRequestReceipt(for: [])?.request.request?.allHTTPHeaderFields?["Accept"]
+        button.af_cancelImageRequest(for: [])
 
         // Then
         XCTAssertNotNil(acceptField)

--- a/Tests/UIImage+AlamofireImageTests.swift
+++ b/Tests/UIImage+AlamofireImageTests.swift
@@ -62,18 +62,18 @@ extension UIImage {
         guard images == nil else { return nil }
 
         // Do not attempt to render if not backed by a CGImage
-        guard let imageRef = CGImage(copy: cgImage!) else { return nil }
+        guard let image = cgImage?.copy() else { return nil }
 
-        let width = imageRef.width
-        let height = imageRef.height
-        let bitsPerComponent = imageRef.bitsPerComponent
+        let width = image.width
+        let height = image.height
+        let bitsPerComponent = image.bitsPerComponent
 
         // Do not attempt to render if too large or has more than 8-bit components
         guard width * height <= 4096 * 4096 && bitsPerComponent <= 8 else { return nil }
 
         let bytesPerRow: Int = 0
         let colorSpace = CGColorSpaceCreateDeviceRGB()
-        var bitmapInfo = imageRef.bitmapInfo
+        var bitmapInfo = image.bitmapInfo
 
         // Fix alpha channel issues if necessary
         let alpha = (bitmapInfo.rawValue & CGBitmapInfo.alphaInfoMask.rawValue)
@@ -87,15 +87,22 @@ extension UIImage {
         }
 
         // Render the image
-        let context = CGContext(data: nil, width: width, height: height, bitsPerComponent: bitsPerComponent, bytesPerRow: bytesPerRow, space: colorSpace, bitmapInfo: bitmapInfo.rawValue)
-        context?.draw(in: CGRect(x: 0.0, y: 0.0, width: CGFloat(width), height: CGFloat(height)), image: imageRef)
+        let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: bitsPerComponent,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo.rawValue
+        )
+
+        context?.draw(image, in: CGRect(x: 0.0, y: 0.0, width: CGFloat(width), height: CGFloat(height)))
 
         // Make sure the inflation was successful
-        guard let renderedImageRef = context?.makeImage() else { return nil }
+        guard let renderedImage = context?.makeImage() else { return nil }
 
-        let renderedImage = UIImage(cgImage: renderedImageRef, scale: scale, orientation: imageOrientation)
-
-        return renderedImage
+        return UIImage(cgImage: renderedImage, scale: scale, orientation: imageOrientation)
     }
 
     /**

--- a/Tests/UIImageTests.swift
+++ b/Tests/UIImageTests.swift
@@ -168,10 +168,10 @@ class UIImageTestCase: BaseTestCase {
         let h = Int(round(size.height))
 
         // When
-        let scaledAppleImage = appleImage.af_imageScaledTo(size)
-        let scaledPirateImage = pirateImage.af_imageScaledTo(size)
-        let scaledRainbowImage = rainbowImage.af_imageScaledTo(size)
-        let scaledUnicornImage = unicornImage.af_imageScaledTo(size)
+        let scaledAppleImage = appleImage.af_imageScaled(to: size)
+        let scaledPirateImage = pirateImage.af_imageScaled(to: size)
+        let scaledRainbowImage = rainbowImage.af_imageScaled(to: size)
+        let scaledUnicornImage = unicornImage.af_imageScaled(to: size)
 
         // Then
         let expectedAppleImage = image(forResource: "apple-scaled-\(w)x\(h)-@\(scale)x", withExtension: "png")
@@ -208,10 +208,10 @@ class UIImageTestCase: BaseTestCase {
         let h = Int(round(size.height))
 
         // When
-        let scaledAppleImage = appleImage.af_imageAspectScaledToFit(size)
-        let scaledPirateImage = pirateImage.af_imageAspectScaledToFit(size)
-        let scaledRainbowImage = rainbowImage.af_imageAspectScaledToFit(size)
-        let scaledUnicornImage = unicornImage.af_imageAspectScaledToFit(size)
+        let scaledAppleImage = appleImage.af_imageAspectScaled(toFit: size)
+        let scaledPirateImage = pirateImage.af_imageAspectScaled(toFit: size)
+        let scaledRainbowImage = rainbowImage.af_imageAspectScaled(toFit: size)
+        let scaledUnicornImage = unicornImage.af_imageAspectScaled(toFit: size)
 
         // Then
         let expectedAppleImage = image(forResource: "apple-aspect.scaled.to.fit-\(w)x\(h)-@\(scale)x", withExtension: "png")
@@ -248,10 +248,10 @@ class UIImageTestCase: BaseTestCase {
         let h = Int(round(size.height))
 
         // When
-        let scaledAppleImage = appleImage.af_imageAspectScaledToFill(size)
-        let scaledPirateImage = pirateImage.af_imageAspectScaledToFill(size)
-        let scaledRainbowImage = rainbowImage.af_imageAspectScaledToFill(size)
-        let scaledUnicornImage = unicornImage.af_imageAspectScaledToFill(size)
+        let scaledAppleImage = appleImage.af_imageAspectScaled(toFill: size)
+        let scaledPirateImage = pirateImage.af_imageAspectScaled(toFill: size)
+        let scaledRainbowImage = rainbowImage.af_imageAspectScaled(toFill: size)
+        let scaledUnicornImage = unicornImage.af_imageAspectScaled(toFill: size)
 
         // Then
         let expectedAppleImage = image(forResource: "apple-aspect.scaled.to.fill-\(w)x\(h)-@\(scale)x", withExtension: "png")
@@ -278,10 +278,10 @@ class UIImageTestCase: BaseTestCase {
         let r = Int(round(radius))
 
         // When
-        let roundedAppleImage = appleImage.af_imageWithRoundedCornerRadius(radius, divideRadiusByImageScale: true)
-        let roundedPirateImage = pirateImage.af_imageWithRoundedCornerRadius(radius, divideRadiusByImageScale: true)
-        let roundedRainbowImage = rainbowImage.af_imageWithRoundedCornerRadius(radius, divideRadiusByImageScale: true)
-        let roundedUnicornImage = unicornImage.af_imageWithRoundedCornerRadius(radius, divideRadiusByImageScale: true)
+        let roundedAppleImage = appleImage.af_imageRounded(withCornerRadius: radius, divideRadiusByImageScale: true)
+        let roundedPirateImage = pirateImage.af_imageRounded(withCornerRadius: radius, divideRadiusByImageScale: true)
+        let roundedRainbowImage = rainbowImage.af_imageRounded(withCornerRadius: radius, divideRadiusByImageScale: true)
+        let roundedUnicornImage = unicornImage.af_imageRounded(withCornerRadius: radius, divideRadiusByImageScale: true)
 
         // Then
         let expectedAppleImage = image(forResource: "apple-radius-\(r)", withExtension: "png")
@@ -346,7 +346,7 @@ class UIImageTestCase: BaseTestCase {
         let parameters: [String: Any] = ["inputRadius": 8]
 
         // When
-        let blurredImage = unicornImage.af_imageWithAppliedCoreImageFilter("CIGaussianBlur", filterParameters: parameters)
+        let blurredImage = unicornImage.af_imageFiltered(withCoreImageFilter: "CIGaussianBlur", parameters: parameters)
 
         // Then
         if let blurredImage = blurredImage {
@@ -361,7 +361,7 @@ class UIImageTestCase: BaseTestCase {
 
     func testThatImageWithAppliedSepiaToneFilterReturnsSepiaImage() {
         // Given, When
-        let sepiaImage = unicornImage.af_imageWithAppliedCoreImageFilter("CISepiaTone")
+        let sepiaImage = unicornImage.af_imageFiltered(withCoreImageFilter: "CISepiaTone")
 
         // Then
         if let sepiaImage = sepiaImage {
@@ -377,7 +377,7 @@ class UIImageTestCase: BaseTestCase {
         let filterName = "SomeFilterThatDoesNotExist"
 
         // When
-        let filteredImage = unicornImage.af_imageWithAppliedCoreImageFilter(filterName)
+        let filteredImage = unicornImage.af_imageFiltered(withCoreImageFilter: filterName)
 
         // Then
         XCTAssertNil(filteredImage, "filtered image should be nil")

--- a/Tests/UIImageTests.swift
+++ b/Tests/UIImageTests.swift
@@ -31,10 +31,10 @@ class UIImageTestCase: BaseTestCase {
 
     // MARK: - Properties
 
-    var appleImage: UIImage { return imageForResource("apple", withExtension: "jpg") }
-    var pirateImage: UIImage { return imageForResource("pirate", withExtension: "jpg") }
-    var rainbowImage: UIImage { return imageForResource("rainbow", withExtension: "jpg") }
-    var unicornImage: UIImage { return imageForResource("unicorn", withExtension: "png") }
+    var appleImage: UIImage { return image(forResource: "apple", withExtension: "jpg") }
+    var pirateImage: UIImage { return image(forResource: "pirate", withExtension: "jpg") }
+    var rainbowImage: UIImage { return image(forResource: "rainbow", withExtension: "jpg") }
+    var unicornImage: UIImage { return image(forResource: "unicorn", withExtension: "png") }
 
     let scale = Int(round(UIScreen.main.scale))
 
@@ -46,7 +46,7 @@ class UIImageTestCase: BaseTestCase {
 
     func testThatHundredsOfLargeImagesCanBeInitializedAcrossMultipleThreads() {
         // Given
-        let url = urlForResource("huge_map", withExtension: "jpg")
+        let url = self.url(forResource: "huge_map", withExtension: "jpg")
         let data = try! Data(contentsOf: url)
 
         let lock = NSLock()
@@ -80,7 +80,7 @@ class UIImageTestCase: BaseTestCase {
 
     func testThatHundredsOfLargeImagesCanBeInitializedAcrossMultipleThreadsWithThreadSafeInitializers() {
         // Given
-        let url = urlForResource("huge_map", withExtension: "jpg")
+        let url = self.url(forResource: "huge_map", withExtension: "jpg")
         let data = try! Data(contentsOf: url)
 
         let lock = NSLock()
@@ -92,8 +92,8 @@ class UIImageTestCase: BaseTestCase {
             let expectation = self.expectation(description: "image should be created successfully")
 
             DispatchQueue.global(qos: .utility).async {
-                let image = UIImage.af_threadSafeImageWithData(data)
-                let imageWithScale = UIImage.af_threadSafeImageWithData(data, scale: CGFloat(self.scale))
+                let image = UIImage.af_threadSafeImage(with: data)
+                let imageWithScale = UIImage.af_threadSafeImage(with: data, scale: CGFloat(self.scale))
 
                 lock.lock()
                 images.append(image)
@@ -116,8 +116,8 @@ class UIImageTestCase: BaseTestCase {
 
     func testThatImageCanBeInflated() {
         // Given
-        let rainbowImage = imageForResource("rainbow", withExtension: "jpg")
-        let unicornImage = imageForResource("unicorn", withExtension: "png")
+        let rainbowImage = image(forResource: "rainbow", withExtension: "jpg")
+        let unicornImage = image(forResource: "unicorn", withExtension: "png")
 
         // When, Then
         rainbowImage.af_inflate()
@@ -126,7 +126,7 @@ class UIImageTestCase: BaseTestCase {
 
     func testThatImageThatHasAlreadyBeenInflatedIsNotInflatedAgain() {
         // Given
-        let unicornImage = imageForResource("unicorn", withExtension: "png")
+        let unicornImage = image(forResource: "unicorn", withExtension: "png")
         unicornImage.af_inflate()
 
         // When, Then
@@ -168,16 +168,16 @@ class UIImageTestCase: BaseTestCase {
         let h = Int(round(size.height))
 
         // When
-        let scaledAppleImage = appleImage.af_imageScaledToSize(size)
-        let scaledPirateImage = pirateImage.af_imageScaledToSize(size)
-        let scaledRainbowImage = rainbowImage.af_imageScaledToSize(size)
-        let scaledUnicornImage = unicornImage.af_imageScaledToSize(size)
+        let scaledAppleImage = appleImage.af_imageScaledTo(size)
+        let scaledPirateImage = pirateImage.af_imageScaledTo(size)
+        let scaledRainbowImage = rainbowImage.af_imageScaledTo(size)
+        let scaledUnicornImage = unicornImage.af_imageScaledTo(size)
 
         // Then
-        let expectedAppleImage = imageForResource("apple-scaled-\(w)x\(h)-@\(scale)x", withExtension: "png")
-        let expectedPirateImage = imageForResource("pirate-scaled-\(w)x\(h)-@\(scale)x", withExtension: "png")
-        let expectedRainbowImage = imageForResource("rainbow-scaled-\(w)x\(h)-@\(scale)x", withExtension: "png")
-        let expectedUnicornImage = imageForResource("unicorn-scaled-\(w)x\(h)-@\(scale)x", withExtension: "png")
+        let expectedAppleImage = image(forResource: "apple-scaled-\(w)x\(h)-@\(scale)x", withExtension: "png")
+        let expectedPirateImage = image(forResource: "pirate-scaled-\(w)x\(h)-@\(scale)x", withExtension: "png")
+        let expectedRainbowImage = image(forResource: "rainbow-scaled-\(w)x\(h)-@\(scale)x", withExtension: "png")
+        let expectedUnicornImage = image(forResource: "unicorn-scaled-\(w)x\(h)-@\(scale)x", withExtension: "png")
 
         XCTAssertTrue(scaledAppleImage.af_isEqualToImage(expectedAppleImage), "scaled apple image pixels do not match")
         XCTAssertTrue(scaledPirateImage.af_isEqualToImage(expectedPirateImage), "scaled pirate image pixels do not match")
@@ -208,16 +208,16 @@ class UIImageTestCase: BaseTestCase {
         let h = Int(round(size.height))
 
         // When
-        let scaledAppleImage = appleImage.af_imageAspectScaledToFitSize(size)
-        let scaledPirateImage = pirateImage.af_imageAspectScaledToFitSize(size)
-        let scaledRainbowImage = rainbowImage.af_imageAspectScaledToFitSize(size)
-        let scaledUnicornImage = unicornImage.af_imageAspectScaledToFitSize(size)
+        let scaledAppleImage = appleImage.af_imageAspectScaledToFit(size)
+        let scaledPirateImage = pirateImage.af_imageAspectScaledToFit(size)
+        let scaledRainbowImage = rainbowImage.af_imageAspectScaledToFit(size)
+        let scaledUnicornImage = unicornImage.af_imageAspectScaledToFit(size)
 
         // Then
-        let expectedAppleImage = imageForResource("apple-aspect.scaled.to.fit-\(w)x\(h)-@\(scale)x", withExtension: "png")
-        let expectedPirateImage = imageForResource("pirate-aspect.scaled.to.fit-\(w)x\(h)-@\(scale)x", withExtension: "png")
-        let expectedRainbowImage = imageForResource("rainbow-aspect.scaled.to.fit-\(w)x\(h)-@\(scale)x", withExtension: "png")
-        let expectedUnicornImage = imageForResource("unicorn-aspect.scaled.to.fit-\(w)x\(h)-@\(scale)x", withExtension: "png")
+        let expectedAppleImage = image(forResource: "apple-aspect.scaled.to.fit-\(w)x\(h)-@\(scale)x", withExtension: "png")
+        let expectedPirateImage = image(forResource: "pirate-aspect.scaled.to.fit-\(w)x\(h)-@\(scale)x", withExtension: "png")
+        let expectedRainbowImage = image(forResource: "rainbow-aspect.scaled.to.fit-\(w)x\(h)-@\(scale)x", withExtension: "png")
+        let expectedUnicornImage = image(forResource: "unicorn-aspect.scaled.to.fit-\(w)x\(h)-@\(scale)x", withExtension: "png")
 
         XCTAssertTrue(scaledAppleImage.af_isEqualToImage(expectedAppleImage, withinTolerance: 4), "scaled apple image pixels do not match")
         XCTAssertTrue(scaledPirateImage.af_isEqualToImage(expectedPirateImage), "scaled pirate image pixels do not match")
@@ -248,16 +248,16 @@ class UIImageTestCase: BaseTestCase {
         let h = Int(round(size.height))
 
         // When
-        let scaledAppleImage = appleImage.af_imageAspectScaledToFillSize(size)
-        let scaledPirateImage = pirateImage.af_imageAspectScaledToFillSize(size)
-        let scaledRainbowImage = rainbowImage.af_imageAspectScaledToFillSize(size)
-        let scaledUnicornImage = unicornImage.af_imageAspectScaledToFillSize(size)
+        let scaledAppleImage = appleImage.af_imageAspectScaledToFill(size)
+        let scaledPirateImage = pirateImage.af_imageAspectScaledToFill(size)
+        let scaledRainbowImage = rainbowImage.af_imageAspectScaledToFill(size)
+        let scaledUnicornImage = unicornImage.af_imageAspectScaledToFill(size)
 
         // Then
-        let expectedAppleImage = imageForResource("apple-aspect.scaled.to.fill-\(w)x\(h)-@\(scale)x", withExtension: "png")
-        let expectedPirateImage = imageForResource("pirate-aspect.scaled.to.fill-\(w)x\(h)-@\(scale)x", withExtension: "png")
-        let expectedRainbowImage = imageForResource("rainbow-aspect.scaled.to.fill-\(w)x\(h)-@\(scale)x", withExtension: "png")
-        let expectedUnicornImage = imageForResource("unicorn-aspect.scaled.to.fill-\(w)x\(h)-@\(scale)x", withExtension: "png")
+        let expectedAppleImage = image(forResource: "apple-aspect.scaled.to.fill-\(w)x\(h)-@\(scale)x", withExtension: "png")
+        let expectedPirateImage = image(forResource: "pirate-aspect.scaled.to.fill-\(w)x\(h)-@\(scale)x", withExtension: "png")
+        let expectedRainbowImage = image(forResource: "rainbow-aspect.scaled.to.fill-\(w)x\(h)-@\(scale)x", withExtension: "png")
+        let expectedUnicornImage = image(forResource: "unicorn-aspect.scaled.to.fill-\(w)x\(h)-@\(scale)x", withExtension: "png")
 
         XCTAssertTrue(scaledAppleImage.af_isEqualToImage(expectedAppleImage), "scaled apple image pixels do not match")
         XCTAssertTrue(scaledPirateImage.af_isEqualToImage(expectedPirateImage), "scaled pirate image pixels do not match")
@@ -284,10 +284,10 @@ class UIImageTestCase: BaseTestCase {
         let roundedUnicornImage = unicornImage.af_imageWithRoundedCornerRadius(radius, divideRadiusByImageScale: true)
 
         // Then
-        let expectedAppleImage = imageForResource("apple-radius-\(r)", withExtension: "png")
-        let expectedPirateImage = imageForResource("pirate-radius-\(r)", withExtension: "png")
-        let expectedRainbowImage = imageForResource("rainbow-radius-\(r)", withExtension: "png")
-        let expectedUnicornImage = imageForResource("unicorn-radius-\(r)", withExtension: "png")
+        let expectedAppleImage = image(forResource: "apple-radius-\(r)", withExtension: "png")
+        let expectedPirateImage = image(forResource: "pirate-radius-\(r)", withExtension: "png")
+        let expectedRainbowImage = image(forResource: "rainbow-radius-\(r)", withExtension: "png")
+        let expectedUnicornImage = image(forResource: "unicorn-radius-\(r)", withExtension: "png")
 
         XCTAssertTrue(roundedAppleImage.af_isEqualToImage(expectedAppleImage), "rounded apple image pixels do not match")
         XCTAssertTrue(roundedPirateImage.af_isEqualToImage(expectedPirateImage), "rounded pirate image pixels do not match")
@@ -308,10 +308,10 @@ class UIImageTestCase: BaseTestCase {
         let circularUnicornImage = unicornImage.af_imageRoundedIntoCircle()
 
         // Then
-        let expectedAppleImage = imageForResource("apple-circle", withExtension: "png")
-        let expectedPirateImage = imageForResource("pirate-circle", withExtension: "png")
-        let expectedRainbowImage = imageForResource("rainbow-circle", withExtension: "png")
-        let expectedUnicornImage = imageForResource("unicorn-circle", withExtension: "png")
+        let expectedAppleImage = image(forResource: "apple-circle", withExtension: "png")
+        let expectedPirateImage = image(forResource: "pirate-circle", withExtension: "png")
+        let expectedRainbowImage = image(forResource: "rainbow-circle", withExtension: "png")
+        let expectedUnicornImage = image(forResource: "unicorn-circle", withExtension: "png")
 
         XCTAssertTrue(circularAppleImage.af_isEqualToImage(expectedAppleImage), "rounded apple image pixels do not match")
         XCTAssertTrue(circularPirateImage.af_isEqualToImage(expectedPirateImage), "rounded pirate image pixels do not match")
@@ -350,7 +350,7 @@ class UIImageTestCase: BaseTestCase {
 
         // Then
         if let blurredImage = blurredImage {
-            let expectedBlurredImage = imageForResource("unicorn-blurred-8", withExtension: "png")
+            let expectedBlurredImage = image(forResource: "unicorn-blurred-8", withExtension: "png")
             let pixelsMatch = blurredImage.af_isEqualToImage(expectedBlurredImage)
 
             XCTAssertTrue(pixelsMatch, "pixels match should be true")
@@ -365,7 +365,7 @@ class UIImageTestCase: BaseTestCase {
 
         // Then
         if let sepiaImage = sepiaImage {
-            let expectedSepiaImage = imageForResource("unicorn-sepia.tone", withExtension: "png")
+            let expectedSepiaImage = image(forResource: "unicorn-sepia.tone", withExtension: "png")
             XCTAssertTrue(sepiaImage.af_isEqualToImage(expectedSepiaImage), "sepia image pixels do not match")
         } else {
             XCTFail("sepia image should not be nil")

--- a/Tests/UIImageTests.swift
+++ b/Tests/UIImageTests.swift
@@ -46,8 +46,8 @@ class UIImageTestCase: BaseTestCase {
 
     func testThatHundredsOfLargeImagesCanBeInitializedAcrossMultipleThreads() {
         // Given
-        let URL = URLForResource("huge_map", withExtension: "jpg")
-        let data = try! Data(contentsOf: URL)
+        let url = urlForResource("huge_map", withExtension: "jpg")
+        let data = try! Data(contentsOf: url)
 
         let lock = NSLock()
         var images: [UIImage?] = []
@@ -80,8 +80,8 @@ class UIImageTestCase: BaseTestCase {
 
     func testThatHundredsOfLargeImagesCanBeInitializedAcrossMultipleThreadsWithThreadSafeInitializers() {
         // Given
-        let URL = URLForResource("huge_map", withExtension: "jpg")
-        let data = try! Data(contentsOf: URL)
+        let url = urlForResource("huge_map", withExtension: "jpg")
+        let data = try! Data(contentsOf: url)
 
         let lock = NSLock()
         var images: [UIImage?] = []
@@ -343,7 +343,7 @@ class UIImageTestCase: BaseTestCase {
 
     func testThatImageWithAppliedGaussianBlurFilterReturnsBlurredImage() {
         // Given
-        let parameters: [String: AnyObject] = ["inputRadius": 8]
+        let parameters: [String: Any] = ["inputRadius": 8]
 
         // When
         let blurredImage = unicornImage.af_imageWithAppliedCoreImageFilter("CIGaussianBlur", filterParameters: parameters)

--- a/Tests/UIImageViewTests.swift
+++ b/Tests/UIImageViewTests.swift
@@ -58,7 +58,7 @@ private class TestImageView: UIImageView {
 // MARK: -
 
 class UIImageViewTestCase: BaseTestCase {
-    let url = Foundation.URL(string: "https://httpbin.org/image/jpeg")!
+    let url = URL(string: "https://httpbin.org/image/jpeg")!
 
     // MARK: - Setup and Teardown
 
@@ -66,8 +66,8 @@ class UIImageViewTestCase: BaseTestCase {
         super.setUp()
 
         ImageDownloader.defaultURLCache().removeAllCachedResponses()
-        ImageDownloader.defaultInstance.imageCache?.removeAllImages()
-        UIImageView.af_sharedImageDownloader = ImageDownloader.defaultInstance
+        ImageDownloader.default.imageCache?.removeAllImages()
+        UIImageView.af_sharedImageDownloader = ImageDownloader.default
     }
 
     // MARK: - Image Download
@@ -83,7 +83,7 @@ class UIImageViewTestCase: BaseTestCase {
         }
 
         // When
-        imageView.af_setImageWithURL(url)
+        imageView.af_setImage(withURL: url)
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -101,8 +101,8 @@ class UIImageViewTestCase: BaseTestCase {
         }
 
         // When
-        imageView.af_setImageWithURL(url)
-        imageView.af_setImageWithURL(url)
+        imageView.af_setImage(withURL: url)
+        imageView.af_setImage(withURL: url)
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -121,7 +121,7 @@ class UIImageViewTestCase: BaseTestCase {
         }
 
         // When
-        imageView.af_setImageWithURL(url)
+        imageView.af_setImage(withURL: url)
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -146,7 +146,7 @@ class UIImageViewTestCase: BaseTestCase {
         imageView.af_imageDownloader = imageDownloader
 
         // When
-        imageView.af_setImageWithURL(url)
+        imageView.af_setImage(withURL: url)
         let activeRequestCount = imageDownloader.activeRequestCount
 
         waitForExpectations(timeout: timeout, handler: nil)
@@ -163,18 +163,18 @@ class UIImageViewTestCase: BaseTestCase {
         // Given
         let imageView = UIImageView()
 
-        let downloader = ImageDownloader.defaultInstance
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let downloader = ImageDownloader.default
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
-        downloader.downloadImage(urlRequest: download) { _ in
+        downloader.download(urlRequest) { _ in
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // When
-        imageView.af_setImageWithURL(url)
+        imageView.af_setImage(withURL: url)
         imageView.af_cancelImageRequest()
 
         // Then
@@ -185,18 +185,18 @@ class UIImageViewTestCase: BaseTestCase {
         // Given
         let imageView = UIImageView()
 
-        let downloader = ImageDownloader.defaultInstance
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let downloader = ImageDownloader.default
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
-        downloader.downloadImage(urlRequest: download, filter: CircleFilter()) { _ in
+        downloader.download(urlRequest, filter: CircleFilter()) { _ in
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // When
-        imageView.af_setImageWithURL(url, filter: CircleFilter())
+        imageView.af_setImage(withURL: url, filter: CircleFilter())
         imageView.af_cancelImageRequest()
 
         // Then
@@ -221,7 +221,7 @@ class UIImageViewTestCase: BaseTestCase {
 
     func testThatPlaceholderImageIsDisplayedUntilImageIsDownloadedFromURL() {
         // Given
-        let placeholderImage = imageForResource("pirate", withExtension: "jpg")
+        let placeholderImage = image(forResource: "pirate", withExtension: "jpg")
         let expectation = self.expectation(description: "image should download successfully")
 
         var imageDownloadComplete = false
@@ -230,7 +230,7 @@ class UIImageViewTestCase: BaseTestCase {
         let imageView = TestImageView()
 
         // When
-        imageView.af_setImageWithURL(url, placeholderImage: placeholderImage)
+        imageView.af_setImage(withURL: url, placeholderImage: placeholderImage)
         let initialImageEqualsPlaceholderImage = imageView.image === placeholderImage
 
         imageView.imageObserver = {
@@ -249,20 +249,20 @@ class UIImageViewTestCase: BaseTestCase {
 
     func testThatPlaceholderIsNeverDisplayedIfCachedImageIsAvailable() {
         // Given
-        let placeholderImage = imageForResource("pirate", withExtension: "jpg")
+        let placeholderImage = image(forResource: "pirate", withExtension: "jpg")
         let imageView = UIImageView()
 
-        let downloader = ImageDownloader.defaultInstance
-        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
+        let downloader = ImageDownloader.default
+        let urlRequest = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
-        downloader.downloadImage(urlRequest: download) { _ in
+        downloader.download(urlRequest) { _ in
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
         // When
-        imageView.af_setImageWithURL(url, placeholderImage: placeholderImage)
+        imageView.af_setImage(withURL: url, placeholderImage: placeholderImage)
 
         // Then
         XCTAssertNotNil(imageView.image, "image view image should not be nil")
@@ -285,7 +285,7 @@ class UIImageViewTestCase: BaseTestCase {
         }
 
         // When
-        imageView.af_setImageWithURL(url, filter: filter)
+        imageView.af_setImage(withURL: url, filter: filter)
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -310,7 +310,7 @@ class UIImageViewTestCase: BaseTestCase {
         }
 
         // When
-        imageView.af_setImageWithURL(url, placeholderImage: nil, filter: nil, imageTransition: .crossDissolve(0.5))
+        imageView.af_setImage(withURL: url, placeholderImage: nil, filter: nil, imageTransition: .crossDissolve(0.5))
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -326,51 +326,51 @@ class UIImageViewTestCase: BaseTestCase {
         // When
         let expectation1 = expectation(description: "image download should succeed")
         imageView.imageObserver = { expectation1.fulfill() }
-        imageView.af_setImageWithURL(url, imageTransition: .none)
+        imageView.af_setImage(withURL: url, imageTransition: .noTransition)
         waitForExpectations(timeout: timeout, handler: nil)
 
         let expectation2 = expectation(description: "image download should succeed")
         imageView.imageObserver = { expectation2.fulfill() }
-        ImageDownloader.defaultInstance.imageCache?.removeAllImages()
-        imageView.af_setImageWithURL(url, imageTransition: .crossDissolve(0.1))
+        ImageDownloader.default.imageCache?.removeAllImages()
+        imageView.af_setImage(withURL: url, imageTransition: .crossDissolve(0.1))
         waitForExpectations(timeout: timeout, handler: nil)
 
         let expectation3 = expectation(description: "image download should succeed")
         imageView.imageObserver = { expectation3.fulfill() }
-        ImageDownloader.defaultInstance.imageCache?.removeAllImages()
-        imageView.af_setImageWithURL(url, imageTransition: .curlDown(0.1))
+        ImageDownloader.default.imageCache?.removeAllImages()
+        imageView.af_setImage(withURL: url, imageTransition: .curlDown(0.1))
         waitForExpectations(timeout: timeout, handler: nil)
 
         let expectation4 = expectation(description: "image download should succeed")
         imageView.imageObserver = { expectation4.fulfill() }
-        ImageDownloader.defaultInstance.imageCache?.removeAllImages()
-        imageView.af_setImageWithURL(url, imageTransition: .curlUp(0.1))
+        ImageDownloader.default.imageCache?.removeAllImages()
+        imageView.af_setImage(withURL: url, imageTransition: .curlUp(0.1))
         waitForExpectations(timeout: timeout, handler: nil)
 
         let expectation5 = expectation(description: "image download should succeed")
         imageView.imageObserver = { expectation5.fulfill() }
-        ImageDownloader.defaultInstance.imageCache?.removeAllImages()
-        imageView.af_setImageWithURL(url, imageTransition: .flipFromBottom(0.1))
+        ImageDownloader.default.imageCache?.removeAllImages()
+        imageView.af_setImage(withURL: url, imageTransition: .flipFromBottom(0.1))
         waitForExpectations(timeout: timeout, handler: nil)
 
         let expectation6 = expectation(description: "image download should succeed")
         imageView.imageObserver = { expectation6.fulfill() }
-        ImageDownloader.defaultInstance.imageCache?.removeAllImages()
-        imageView.af_setImageWithURL(url, imageTransition: .flipFromLeft(0.1))
+        ImageDownloader.default.imageCache?.removeAllImages()
+        imageView.af_setImage(withURL: url, imageTransition: .flipFromLeft(0.1))
         waitForExpectations(timeout: timeout, handler: nil)
 
         let expectation7 = expectation(description: "image download should succeed")
         imageView.imageObserver = { expectation7.fulfill() }
-        ImageDownloader.defaultInstance.imageCache?.removeAllImages()
-        imageView.af_setImageWithURL(url, imageTransition: .flipFromRight(0.1))
+        ImageDownloader.default.imageCache?.removeAllImages()
+        imageView.af_setImage(withURL: url, imageTransition: .flipFromRight(0.1))
         waitForExpectations(timeout: timeout, handler: nil)
 
         let expectation8 = expectation(description: "image download should succeed")
         imageView.imageObserver = {
             expectation8.fulfill()
         }
-        ImageDownloader.defaultInstance.imageCache?.removeAllImages()
-        imageView.af_setImageWithURL(url, imageTransition: .flipFromTop(0.1))
+        ImageDownloader.default.imageCache?.removeAllImages()
+        imageView.af_setImage(withURL: url, imageTransition: .flipFromTop(0.1))
         waitForExpectations(timeout: timeout, handler: nil)
 
         let expectation9 = expectation(description: "image download should succeed")
@@ -378,9 +378,9 @@ class UIImageViewTestCase: BaseTestCase {
             imageTransitionsComplete = true
             expectation9.fulfill()
         }
-        ImageDownloader.defaultInstance.imageCache?.removeAllImages()
-        imageView.af_setImageWithURL(
-            url,
+        ImageDownloader.default.imageCache?.removeAllImages()
+        imageView.af_setImage(
+            withURL: url,
             imageTransition: .custom(
                 duration: 0.5,
                 animationOptions: UIViewAnimationOptions(),
@@ -401,7 +401,7 @@ class UIImageViewTestCase: BaseTestCase {
         // Given
         let imageView = UIImageView()
 
-        let urlRequest: Foundation.URLRequest = {
+        let urlRequest: URLRequest = {
             var request = URLRequest(url: url)
             request.addValue("image/*", forHTTPHeaderField: "Accept")
             return request
@@ -413,11 +413,11 @@ class UIImageViewTestCase: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        imageView.af_setImageWithURLRequest(
-            urlRequest,
+        imageView.af_setImage(
+            withURLRequest: urlRequest,
             placeholderImage: nil,
             filter: nil,
-            imageTransition: .none,
+            imageTransition: .noTransition,
             completion: { closureResponse in
                 completionHandlerCalled = true
                 result = closureResponse.result
@@ -436,7 +436,7 @@ class UIImageViewTestCase: BaseTestCase {
     func testThatCompletionHandlerIsCalledWhenImageDownloadFails() {
         // Given
         let imageView = UIImageView()
-        let URLRequest = Foundation.URLRequest(url: Foundation.URL(string: "domain-name-does-not-exist")!)
+        let urlRequest = URLRequest(url: URL(string: "domain-name-does-not-exist")!)
 
         let expectation = self.expectation(description: "image download should succeed")
 
@@ -444,11 +444,11 @@ class UIImageViewTestCase: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        imageView.af_setImageWithURLRequest(
-            URLRequest,
+        imageView.af_setImage(
+            withURLRequest: urlRequest,
             placeholderImage: nil,
             filter: nil,
-            imageTransition: .none,
+            imageTransition: .noTransition,
             completion: { closureResponse in
                 completionHandlerCalled = true
                 result = closureResponse.result
@@ -477,8 +477,8 @@ class UIImageViewTestCase: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        imageView.af_setImageWithURL(
-            url,
+        imageView.af_setImage(
+            withURL: url,
             placeholderImage: nil,
             filter: nil,
             imageTransition: .custom(
@@ -510,7 +510,7 @@ class UIImageViewTestCase: BaseTestCase {
     func testThatImageIsSetWhenReturnedFromCacheAndCompletionHandlerSet() {
         // Given
         let imageView = UIImageView()
-        let urlRequest: Foundation.URLRequest = {
+        let urlRequest: URLRequest = {
             var request = URLRequest(url: url)
             request.addValue("image/*", forHTTPHeaderField: "Accept")
             return request
@@ -519,7 +519,7 @@ class UIImageViewTestCase: BaseTestCase {
         let downloadExpectation = expectation(description: "image download should succeed")
 
         // When
-        UIImageView.af_sharedImageDownloader.downloadImage(urlRequest: urlRequest) { _ in
+        UIImageView.af_sharedImageDownloader.download(urlRequest) { _ in
             downloadExpectation.fulfill()
         }
 
@@ -528,11 +528,11 @@ class UIImageViewTestCase: BaseTestCase {
         let cachedExpectation = expectation(description: "image should be cached")
         var result: Result<UIImage, NSError>?
 
-        imageView.af_setImageWithURLRequest(
-            urlRequest,
+        imageView.af_setImage(
+            withURLRequest: urlRequest,
             placeholderImage: nil,
             filter: nil,
-            imageTransition: .none,
+            imageTransition: .noTransition,
             completion: { closureResponse in
                 result = closureResponse.result
                 cachedExpectation.fulfill()
@@ -551,7 +551,7 @@ class UIImageViewTestCase: BaseTestCase {
     func testThatImageDownloadCanBeCancelled() {
         // Given
         let imageView = UIImageView()
-        let urlRequest = Foundation.URLRequest(url: Foundation.URL(string: "domain-name-does-not-exist")!)
+        let urlRequest = URLRequest(url: URL(string: "domain-name-does-not-exist")!)
 
         let expectation = self.expectation(description: "image download should succeed")
 
@@ -559,11 +559,11 @@ class UIImageViewTestCase: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        imageView.af_setImageWithURLRequest(
-            urlRequest,
+        imageView.af_setImage(
+            withURLRequest: urlRequest,
             placeholderImage: nil,
             filter: nil,
-            imageTransition: .none,
+            imageTransition: .noTransition,
             completion: { closureResponse in
                 completionHandlerCalled = true
                 result = closureResponse.result
@@ -590,21 +590,21 @@ class UIImageViewTestCase: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        imageView.af_setImageWithURLRequest(
-            URLRequest(url: url),
+        imageView.af_setImage(
+            withURLRequest: URLRequest(url: url),
             placeholderImage: nil,
             filter: nil,
-            imageTransition: .none,
+            imageTransition: .noTransition,
             completion: { _ in
                 completion1Called = true
             }
         )
 
-        imageView.af_setImageWithURLRequest(
-            URLRequest(url: Foundation.URL(string: "https://httpbin.org/image/png")!),
+        imageView.af_setImage(
+            withURLRequest: URLRequest(url: URL(string: "https://httpbin.org/image/png")!),
             placeholderImage: nil,
             filter: nil,
-            imageTransition: .none,
+            imageTransition: .noTransition,
             completion: { closureResponse in
                 completion2Called = true
                 result = closureResponse.result
@@ -631,11 +631,11 @@ class UIImageViewTestCase: BaseTestCase {
         var result: Result<UIImage, NSError>?
 
         // When
-        imageView.af_setImageWithURLRequest(
-            URLRequest(url: url),
+        imageView.af_setImage(
+            withURLRequest: URLRequest(url: url),
             placeholderImage: nil,
             filter: nil,
-            imageTransition: .none,
+            imageTransition: .noTransition,
             completion: { _ in
                 completion1Called = true
             }
@@ -643,11 +643,11 @@ class UIImageViewTestCase: BaseTestCase {
 
         imageView.af_cancelImageRequest()
 
-        imageView.af_setImageWithURLRequest(
-            URLRequest(url: url),
+        imageView.af_setImage(
+            withURLRequest: URLRequest(url: url),
             placeholderImage: nil,
             filter: nil,
-            imageTransition: .none,
+            imageTransition: .noTransition,
             completion: { closureResponse in
                 completion2Called = true
                 result = closureResponse.result
@@ -669,7 +669,7 @@ class UIImageViewTestCase: BaseTestCase {
     func testThatImageBehindRedirectCanBeDownloaded() {
         // Given
         let redirectURLString = "https://httpbin.org/image/png"
-        let url = Foundation.URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
+        let url = URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
 
         let expectation = self.expectation(description: "image should download successfully")
         var imageDownloadComplete = false
@@ -680,7 +680,7 @@ class UIImageViewTestCase: BaseTestCase {
         }
 
         // When
-        imageView.af_setImageWithURL(url)
+        imageView.af_setImage(withURL: url)
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -695,7 +695,7 @@ class UIImageViewTestCase: BaseTestCase {
         let imageView = UIImageView()
 
         // When
-        imageView.af_setImageWithURL(url)
+        imageView.af_setImage(withURL: url)
         let acceptField = imageView.af_activeRequestReceipt?.request.request?.allHTTPHeaderFields?["Accept"]
         imageView.af_cancelImageRequest()
 

--- a/Tests/UIImageViewTests.swift
+++ b/Tests/UIImageViewTests.swift
@@ -164,7 +164,7 @@ class UIImageViewTestCase: BaseTestCase {
         let imageView = UIImageView()
 
         let downloader = ImageDownloader.defaultInstance
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         downloader.downloadImage(urlRequest: download) { _ in
@@ -186,7 +186,7 @@ class UIImageViewTestCase: BaseTestCase {
         let imageView = UIImageView()
 
         let downloader = ImageDownloader.defaultInstance
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         downloader.downloadImage(urlRequest: download, filter: CircleFilter()) { _ in
@@ -253,7 +253,7 @@ class UIImageViewTestCase: BaseTestCase {
         let imageView = UIImageView()
 
         let downloader = ImageDownloader.defaultInstance
-        let download = URLRequest(.GET, "https://httpbin.org/image/jpeg")
+        let download = URLRequest(urlString: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
         downloader.downloadImage(urlRequest: download) { _ in
             expectation.fulfill()


### PR DESCRIPTION
This PR updates all the source, test and example logic to compile against Xcode 8 beta 6. It also updates all the APIs to follow the Swift API design guidelines. I also updated all the docstrings to use the new Swift 3 syntax.