### PR TITLE
[iOS] S3 Issue

### DIFF
--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -36,6 +36,7 @@ extension Request {
     static var acceptableImageContentTypes: Set<String> = [
         "image/tiff",
         "image/jpeg",
+        "image/jpg",
         "image/gif",
         "image/png",
         "image/ico",


### PR DESCRIPTION
With current version, when we try to get an S3 image with JPG, AlamofireImage throw an error (403 - contentTypeValidationError)


Of course we can add:
*Request.addAcceptableImageContentTypes(["image/jpg"])*

But it seem's to be better to add it in the library (jpg is a standard format)