### PR TITLE
Rename OS X to macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ env:
   - LANG=en_US.UTF-8
   - WORKSPACE=AlamofireImage.xcworkspace
   - IOS_FRAMEWORK_SCHEME="AlamofireImage iOS"
-  - OSX_FRAMEWORK_SCHEME="AlamofireImage OSX"
+  - MACOS_FRAMEWORK_SCHEME="AlamofireImage macOS"
   - TVOS_FRAMEWORK_SCHEME="AlamofireImage tvOS"
   - WATCHOS_FRAMEWORK_SCHEME="AlamofireImage watchOS"
   - IOS_SDK=iphonesimulator10.0
-  - OSX_SDK=macosx10.12
+  - MACOS_SDK=macosx10.12
   - TVOS_SDK=appletvsimulator10.0
   - WATCHOS_SDK=watchsimulator3.0
   - EXAMPLE_SCHEME="iOS Example"
@@ -26,7 +26,7 @@ env:
     - DESTINATION="OS=10.0,name=Apple TV 1080p"    SCHEME="$TVOS_FRAMEWORK_SCHEME"    SDK="$TVOS_SDK"    RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
     - DESTINATION="OS=9.0,name=Apple TV 1080p"     SCHEME="$TVOS_FRAMEWORK_SCHEME"    SDK="$TVOS_SDK"    RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
 
-    - DESTINATION="arch=x86_64"                    SCHEME="$OSX_FRAMEWORK_SCHEME"     SDK="$OSX_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
+    - DESTINATION="arch=x86_64"                    SCHEME="$MACOS_FRAMEWORK_SCHEME"     SDK="$MACOS_SDK"     RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
 before_install:
   - gem install cocoapods --pre --no-rdoc --no-ri --no-document --quiet
 script:
@@ -37,26 +37,26 @@ script:
 
   # Build Framework in Debug and Run Tests if specified
   - if [ $RUN_TESTS == "YES" ]; then
-      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test ENABLE_TESTABILITY=YES test | xcpretty -c;
+      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO test ENABLE_TESTABILITY=YES test | xcpretty;
     else
-      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
+      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO build | xcpretty;
     fi
 
   # Build Framework in ReleaseTest and Run Tests if specified
   - if [ $RUN_TESTS == "YES" ]; then
-      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO test ENABLE_TESTABILITY=YES test | xcpretty -c;
+      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO test ENABLE_TESTABILITY=YES test | xcpretty;
     else
-      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
+      xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty;
     fi
 
   # Build Example in Debug if specified
   - if [ $BUILD_EXAMPLE == "YES" ]; then
-      xcodebuild -workspace "$WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO build | xcpretty -c;
+      xcodebuild -workspace "$WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO build | xcpretty;
     fi
 
   # Build Example in Release if specified
-  - if [ $BUILD_EXAMPLE == "YES" ]; then 
-      xcodebuild -workspace "$WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty -c; 
+  - if [ $BUILD_EXAMPLE == "YES" ]; then
+      xcodebuild -workspace "$WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty;
     fi
 
   # Temporarily disabling pod lib lint check due to CocoaPods issue: https://github.com/CocoaPods/CocoaPods/issues/5661

--- a/AlamofireImage.xcodeproj/project.pbxproj
+++ b/AlamofireImage.xcodeproj/project.pbxproj
@@ -756,7 +756,7 @@
 		4CD5BCF41D7FBE380055E232 /* AFError+AlamofireImageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AFError+AlamofireImageTests.swift"; sourceTree = "<group>"; };
 		4CE5AAA61B9BF099003530D6 /* Alamofire.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Alamofire.xcodeproj; path = Carthage/Checkouts/Alamofire/Alamofire.xcodeproj; sourceTree = "<group>"; };
 		4CE611321AABC24E00D35044 /* AlamofireImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AlamofireImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4CE611471AABC5C900D35044 /* AlamofireImage OSX Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AlamofireImage OSX Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4CE611471AABC5C900D35044 /* AlamofireImage macOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AlamofireImage macOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CE611541AABC8D900D35044 /* Request+AlamofireImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Request+AlamofireImage.swift"; sourceTree = "<group>"; };
 		4CEBB53F1B93C622001391DE /* ImageCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheTests.swift; sourceTree = "<group>"; };
 		4CFC0A051AB4FEC90004D0B8 /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
@@ -1139,7 +1139,7 @@
 				4C9043771AABBFC5001B4E60 /* AlamofireImage.framework */,
 				4C9043821AABBFC5001B4E60 /* AlamofireImage iOS Tests.xctest */,
 				4CE611321AABC24E00D35044 /* AlamofireImage.framework */,
-				4CE611471AABC5C900D35044 /* AlamofireImage OSX Tests.xctest */,
+				4CE611471AABC5C900D35044 /* AlamofireImage macOS Tests.xctest */,
 				4C4D4EC11B92976900C96855 /* AlamofireImage.framework */,
 				4C16B37D1BA9399500A66EF0 /* AlamofireImage.framework */,
 				4C16B3861BA9399500A66EF0 /* AlamofireImage tvOS Tests.xctest */,
@@ -1334,9 +1334,9 @@
 			productReference = 4C9043821AABBFC5001B4E60 /* AlamofireImage iOS Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		4CE611281AABC24E00D35044 /* AlamofireImage OSX */ = {
+		4CE611281AABC24E00D35044 /* AlamofireImage macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4CE6112F1AABC24E00D35044 /* Build configuration list for PBXNativeTarget "AlamofireImage OSX" */;
+			buildConfigurationList = 4CE6112F1AABC24E00D35044 /* Build configuration list for PBXNativeTarget "AlamofireImage macOS" */;
 			buildPhases = (
 				4CE611291AABC24E00D35044 /* Sources */,
 				4CE6112A1AABC24E00D35044 /* Frameworks */,
@@ -1348,14 +1348,14 @@
 			dependencies = (
 				4CE5AABD1B9BF10C003530D6 /* PBXTargetDependency */,
 			);
-			name = "AlamofireImage OSX";
+			name = "AlamofireImage macOS";
 			productName = AlamofireImage;
 			productReference = 4CE611321AABC24E00D35044 /* AlamofireImage.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		4CE611461AABC5C900D35044 /* AlamofireImage OSX Tests */ = {
+		4CE611461AABC5C900D35044 /* AlamofireImage macOS Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4CE611501AABC5C900D35044 /* Build configuration list for PBXNativeTarget "AlamofireImage OSX Tests" */;
+			buildConfigurationList = 4CE611501AABC5C900D35044 /* Build configuration list for PBXNativeTarget "AlamofireImage macOS Tests" */;
 			buildPhases = (
 				4CE611431AABC5C900D35044 /* Sources */,
 				4CE611441AABC5C900D35044 /* Frameworks */,
@@ -1366,9 +1366,9 @@
 			dependencies = (
 				4CE6114F1AABC5C900D35044 /* PBXTargetDependency */,
 			);
-			name = "AlamofireImage OSX Tests";
+			name = "AlamofireImage macOS Tests";
 			productName = "AlamofireImage OSX Tests";
-			productReference = 4CE611471AABC5C900D35044 /* AlamofireImage OSX Tests.xctest */;
+			productReference = 4CE611471AABC5C900D35044 /* AlamofireImage macOS Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -1436,8 +1436,8 @@
 			targets = (
 				4C9043761AABBFC5001B4E60 /* AlamofireImage iOS */,
 				4C9043811AABBFC5001B4E60 /* AlamofireImage iOS Tests */,
-				4CE611281AABC24E00D35044 /* AlamofireImage OSX */,
-				4CE611461AABC5C900D35044 /* AlamofireImage OSX Tests */,
+				4CE611281AABC24E00D35044 /* AlamofireImage macOS */,
+				4CE611461AABC5C900D35044 /* AlamofireImage macOS Tests */,
 				4C16B37C1BA9399500A66EF0 /* AlamofireImage tvOS */,
 				4C16B3851BA9399500A66EF0 /* AlamofireImage tvOS Tests */,
 				4C4D4EC01B92976900C96855 /* AlamofireImage watchOS */,
@@ -2113,7 +2113,7 @@
 		};
 		4CE6114F1AABC5C900D35044 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 4CE611281AABC24E00D35044 /* AlamofireImage OSX */;
+			target = 4CE611281AABC24E00D35044 /* AlamofireImage macOS */;
 			targetProxy = 4CE6114E1AABC5C900D35044 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -2586,7 +2586,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4CE6112F1AABC24E00D35044 /* Build configuration list for PBXNativeTarget "AlamofireImage OSX" */ = {
+		4CE6112F1AABC24E00D35044 /* Build configuration list for PBXNativeTarget "AlamofireImage macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				4CE611301AABC24E00D35044 /* Debug */,
@@ -2595,7 +2595,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		4CE611501AABC5C900D35044 /* Build configuration list for PBXNativeTarget "AlamofireImage OSX Tests" */ = {
+		4CE611501AABC5C900D35044 /* Build configuration list for PBXNativeTarget "AlamofireImage macOS Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				4CE611511AABC5C900D35044 /* Debug */,

--- a/AlamofireImage.xcodeproj/xcshareddata/xcschemes/AlamofireImage macOS.xcscheme
+++ b/AlamofireImage.xcodeproj/xcshareddata/xcschemes/AlamofireImage macOS.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4CE611281AABC24E00D35044"
                BuildableName = "AlamofireImage.framework"
-               BlueprintName = "AlamofireImage OSX"
+               BlueprintName = "AlamofireImage macOS"
                ReferencedContainer = "container:AlamofireImage.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -29,8 +29,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4CE611461AABC5C900D35044"
-               BuildableName = "AlamofireImage OSX Tests.xctest"
-               BlueprintName = "AlamofireImage OSX Tests"
+               BuildableName = "AlamofireImage macOS Tests.xctest"
+               BlueprintName = "AlamofireImage macOS Tests"
                ReferencedContainer = "container:AlamofireImage.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -47,8 +47,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4CE611461AABC5C900D35044"
-               BuildableName = "AlamofireImage OSX Tests.xctest"
-               BlueprintName = "AlamofireImage OSX Tests"
+               BuildableName = "AlamofireImage macOS Tests.xctest"
+               BlueprintName = "AlamofireImage macOS Tests"
                ReferencedContainer = "container:AlamofireImage.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -58,7 +58,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4CE611281AABC24E00D35044"
             BuildableName = "AlamofireImage.framework"
-            BlueprintName = "AlamofireImage OSX"
+            BlueprintName = "AlamofireImage macOS"
             ReferencedContainer = "container:AlamofireImage.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -80,7 +80,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4CE611281AABC24E00D35044"
             BuildableName = "AlamofireImage.framework"
-            BlueprintName = "AlamofireImage OSX"
+            BlueprintName = "AlamofireImage macOS"
             ReferencedContainer = "container:AlamofireImage.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -98,7 +98,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4CE611281AABC24E00D35044"
             BuildableName = "AlamofireImage.framework"
-            BlueprintName = "AlamofireImage OSX"
+            BlueprintName = "AlamofireImage macOS"
             ReferencedContainer = "container:AlamofireImage.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Doing this helps prioritize the most common problems and requests.
 When reporting issues, please include the following:
 
 * The version of Xcode you're using
-* The version of iOS or OS X you're targeting
+* The version of iOS or macOS you're targeting
 * The full output of any stack trace or compiler error
 * A code snippet that reproduces the described behavior, if applicable
 * Any other details that would be useful in understanding the problem

--- a/Source/Image.swift
+++ b/Source/Image.swift
@@ -27,7 +27,7 @@ import Foundation
 #if os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
 public typealias Image = UIImage
-#elseif os(OSX)
+#elseif os(macOS)
 import Cocoa
 public typealias Image = NSImage
 #endif

--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -27,7 +27,7 @@ import Foundation
 
 #if os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
-#elseif os(OSX)
+#elseif os(macOS)
 import Cocoa
 #endif
 
@@ -83,7 +83,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
             self.totalBytes = {
                 #if os(iOS) || os(tvOS) || os(watchOS)
                     let size = CGSize(width: image.size.width * image.scale, height: image.size.height * image.scale)
-                #elseif os(OSX)
+                #elseif os(macOS)
                     let size = CGSize(width: image.size.width, height: image.size.height)
                 #endif
 

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -27,7 +27,7 @@ import Foundation
 
 #if os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
-#elseif os(OSX)
+#elseif os(macOS)
 import Cocoa
 #endif
 

--- a/Source/ImageFilter.swift
+++ b/Source/ImageFilter.swift
@@ -26,7 +26,7 @@ import Foundation
 
 #if os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
-#elseif os(OSX)
+#elseif os(macOS)
 import Cocoa
 #endif
 

--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -30,7 +30,7 @@ import UIKit
 #elseif os(watchOS)
 import UIKit
 import WatchKit
-#elseif os(OSX)
+#elseif os(macOS)
 import Cocoa
 #endif
 
@@ -148,9 +148,9 @@ extension DataRequest {
         #endif
     }
 
-#elseif os(OSX)
+#elseif os(macOS)
 
-    // MARK: - OSX
+    // MARK: - macOS
 
     /// Creates a response serializer that returns an image initialized from the response data.
     ///

--- a/Tests/BaseTestCase.swift
+++ b/Tests/BaseTestCase.swift
@@ -70,7 +70,7 @@ class BaseTestCase : XCTestCase {
 
         #if os(iOS) || os(tvOS)
             let image = Image.af_threadSafeImage(with: data, scale: UIScreen.main.scale)!
-        #elseif os(OSX)
+        #elseif os(macOS)
             let image = Image(data: data)!
         #endif
 

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -87,7 +87,7 @@ class DataRequestTestCase: BaseTestCase {
                 let expectedSize = CGSize(width: CGFloat(100) / screenScale, height: CGFloat(100) / screenScale)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
                 XCTAssertEqual(image.scale, screenScale, "image scale does not match expected value")
-            #elseif os(OSX)
+            #elseif os(macOS)
                 let expectedSize = CGSize(width: 100.0, height: 100.0)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
             #endif
@@ -123,7 +123,7 @@ class DataRequestTestCase: BaseTestCase {
                 let expectedSize = CGSize(width: CGFloat(239) / screenScale, height: CGFloat(178) / screenScale)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
                 XCTAssertEqual(image.scale, screenScale, "image scale does not match expected value")
-            #elseif os(OSX)
+            #elseif os(macOS)
                 let expectedSize = CGSize(width: 239.0, height: 178.0)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
             #endif
@@ -159,7 +159,7 @@ class DataRequestTestCase: BaseTestCase {
                 let expectedSize = CGSize(width: CGFloat(180) / screenScale, height: CGFloat(260) / screenScale)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
                 XCTAssertEqual(image.scale, screenScale, "image scale does not match expected value")
-            #elseif os(OSX)
+            #elseif os(macOS)
                 let expectedSize = CGSize(width: 180.0, height: 260.0)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
             #endif


### PR DESCRIPTION
1. Rename target `Alamofire OSX` to `Alamofire macOS`.
2. Rename target `Alamofire OSX Tests` to `Alamofire macOS Tests`.
3. Rename scheme `Alamofire OSX` to `Alamofire macOS`.
5. Replace `os(OSX)` with `os(macOS)`.
6. Update CONTRIBUTING.md.
7. Update .travis.yml (also change `xcpretty -c` to `xcpretty` since `-c` is the default argument).

`Alamofire`: https://github.com/Alamofire/Alamofire/pull/1520
`AlamofireNetworkActivityIndicator`: no change needed