### PR TITLE
Feature - Opening Up Subclassing

### DIFF
--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -68,8 +68,8 @@ public protocol ImageRequestCache: ImageCache {
 /// the memory capacity is reached, the image cache is sorted by last access date, then the oldest image is continuously
 /// purged until the preferred memory usage after purge is met. Each time an image is accessed through the cache, the
 /// internal access date of the image is updated.
-public class AutoPurgingImageCache: ImageRequestCache {
-    private class CachedImage {
+open class AutoPurgingImageCache: ImageRequestCache {
+    class CachedImage {
         let image: Image
         let identifier: String
         let totalBytes: UInt64
@@ -104,7 +104,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
     // MARK: Properties
 
     /// The current total memory usage in bytes of all images stored within the cache.
-    public var memoryUsage: UInt64 {
+    open var memoryUsage: UInt64 {
         var memoryUsage: UInt64 = 0
         synchronizationQueue.sync { memoryUsage = self.currentMemoryUsage }
 
@@ -112,11 +112,11 @@ public class AutoPurgingImageCache: ImageRequestCache {
     }
 
     /// The total memory capacity of the cache in bytes.
-    public let memoryCapacity: UInt64
+    open let memoryCapacity: UInt64
 
     /// The preferred memory usage after purge in bytes. During a purge, images will be purged until the memory
     /// capacity drops below this limit.
-    public let preferredMemoryUsageAfterPurge: UInt64
+    open let preferredMemoryUsageAfterPurge: UInt64
 
     private let synchronizationQueue: DispatchQueue
     private var cachedImages: [String: CachedImage]
@@ -171,7 +171,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
     /// - parameter image:      The image to add to the cache.
     /// - parameter request:    The request used to generate the image's unique identifier.
     /// - parameter identifier: The additional identifier to append to the image's unique identifier.
-    public func add(_ image: Image, for request: URLRequest, withIdentifier identifier: String? = nil) {
+    open func add(_ image: Image, for request: URLRequest, withIdentifier identifier: String? = nil) {
         let requestIdentifier = imageCacheKey(for: request, withIdentifier: identifier)
         add(image, withIdentifier: requestIdentifier)
     }
@@ -180,7 +180,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
     ///
     /// - parameter image:      The image to add to the cache.
     /// - parameter identifier: The identifier to use to uniquely identify the image.
-    public func add(_ image: Image, withIdentifier identifier: String) {
+    open func add(_ image: Image, withIdentifier identifier: String) {
         synchronizationQueue.async(flags: [.barrier]) {
             let cachedImage = CachedImage(image, identifier: identifier)
 
@@ -230,7 +230,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
     ///
     /// - returns: `true` if the image was removed, `false` otherwise.
     @discardableResult
-    public func removeImage(for request: URLRequest, withIdentifier identifier: String?) -> Bool {
+    open func removeImage(for request: URLRequest, withIdentifier identifier: String?) -> Bool {
         let requestIdentifier = imageCacheKey(for: request, withIdentifier: identifier)
         return removeImage(withIdentifier: requestIdentifier)
     }
@@ -241,7 +241,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
     ///
     /// - returns: `true` if any images were removed, `false` otherwise.
     @discardableResult
-    public func removeImages(matching request: URLRequest) -> Bool {
+    open func removeImages(matching request: URLRequest) -> Bool {
         let requestIdentifier = imageCacheKey(for: request, withIdentifier: nil)
         var removed = false
 
@@ -263,7 +263,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
     ///
     /// - returns: `true` if the image was removed, `false` otherwise.
     @discardableResult
-    public func removeImage(withIdentifier identifier: String) -> Bool {
+    open func removeImage(withIdentifier identifier: String) -> Bool {
         var removed = false
 
         synchronizationQueue.sync {
@@ -279,8 +279,8 @@ public class AutoPurgingImageCache: ImageRequestCache {
     /// Removes all images stored in the cache.
     ///
     /// - returns: `true` if images were removed from the cache, `false` otherwise.
-    @discardableResult
-    @objc public func removeAllImages() -> Bool {
+    @discardableResult @objc
+    open func removeAllImages() -> Bool {
         var removed = false
 
         synchronizationQueue.sync {
@@ -303,7 +303,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
     /// - parameter identifier: The additional identifier to append to the image's unique identifier.
     ///
     /// - returns: The image if it is stored in the cache, `nil` otherwise.
-    public func image(for request: URLRequest, withIdentifier identifier: String? = nil) -> Image? {
+    open func image(for request: URLRequest, withIdentifier identifier: String? = nil) -> Image? {
         let requestIdentifier = imageCacheKey(for: request, withIdentifier: identifier)
         return image(withIdentifier: requestIdentifier)
     }
@@ -313,7 +313,7 @@ public class AutoPurgingImageCache: ImageRequestCache {
     /// - parameter identifier: The unique identifier for the image.
     ///
     /// - returns: The image if it is stored in the cache, `nil` otherwise.
-    public func image(withIdentifier identifier: String) -> Image? {
+    open func image(withIdentifier identifier: String) -> Image? {
         var image: Image?
 
         synchronizationQueue.sync {
@@ -325,9 +325,15 @@ public class AutoPurgingImageCache: ImageRequestCache {
         return image
     }
 
-    // MARK: Private - Helper Methods
+    // MARK: Image Cache Keys
 
-    private func imageCacheKey(for request: URLRequest, withIdentifier identifier: String?) -> String {
+    /// Returns the unique image cache key for the specified request and additional identifier.
+    ///
+    /// - parameter request:    The request.
+    /// - parameter identifier: The additional identifier.
+    ///
+    /// - returns: The unique image cache key.
+    open func imageCacheKey(for request: URLRequest, withIdentifier identifier: String?) -> String {
         var key = request.url?.absoluteString ?? ""
 
         if let identifier = identifier {

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -35,12 +35,12 @@ import Cocoa
 /// to cancel active requests running on the `ImageDownloader` session. As a general rule, image download requests
 /// should be cancelled using the `RequestReceipt` instead of calling `cancel` directly on the `request` itself. The
 /// `ImageDownloader` is optimized to handle duplicate request scenarios as well as pending versus active downloads.
-public class RequestReceipt {
+open class RequestReceipt {
     /// The download request created by the `ImageDownloader`.
-    public let request: Request
+    open let request: Request
 
     /// The unique identifier for the image filters and completion handlers when duplicate requests are made.
-    public let receiptID: String
+    open let receiptID: String
 
     init(request: Request, receiptID: String) {
         self.request = request
@@ -48,18 +48,22 @@ public class RequestReceipt {
     }
 }
 
+// MARK: -
+
 /// The `ImageDownloader` class is responsible for downloading images in parallel on a prioritized queue. Incoming
 /// downloads are added to the front or back of the queue depending on the download prioritization. Each downloaded
 /// image is cached in the underlying `NSURLCache` as well as the in-memory image cache that supports image filters.
 /// By default, any download request with a cached image equivalent in the image cache will automatically be served the
 /// cached image representation. Additional advanced features include supporting multiple image filters and completion
 /// handlers for a single request.
-public class ImageDownloader {
+open class ImageDownloader {
     /// The completion handler closure used when an image download completes.
     public typealias CompletionHandler = (DataResponse<Image>) -> Void
 
     /// The progress handler closure called periodically during an image download.
     public typealias ProgressHandler = DataRequest.ProgressHandler
+
+    // MARK: Helper Types
 
     /// Defines the order prioritization of incoming download requests being inserted into the queue.
     ///
@@ -89,16 +93,16 @@ public class ImageDownloader {
         }
     }
 
-    // MARK: - Properties
+    // MARK: Properties
 
     /// The image cache used to store all downloaded images in.
-    public let imageCache: ImageRequestCache?
+    open let imageCache: ImageRequestCache?
 
     /// The credential used for authenticating each download request.
-    public private(set) var credential: URLCredential?
+    open private(set) var credential: URLCredential?
 
     /// The underlying Alamofire `Manager` instance used to handle all download requests.
-    public let sessionManager: SessionManager
+    open let sessionManager: SessionManager
 
     let downloadPrioritization: DownloadPrioritization
     let maximumActiveDownloads: Int
@@ -117,15 +121,15 @@ public class ImageDownloader {
         return DispatchQueue(label: name, attributes: .concurrent)
     }()
 
-    // MARK: - Initialization
+    // MARK: Initialization
 
     /// The default instance of `ImageDownloader` initialized with default values.
-    public static let `default` = ImageDownloader()
+    open static let `default` = ImageDownloader()
 
     /// Creates a default `URLSessionConfiguration` with common usage parameter values.
     ///
     /// - returns: The default `URLSessionConfiguration` instance.
-    public class func defaultURLSessionConfiguration() -> URLSessionConfiguration {
+    open class func defaultURLSessionConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.default
 
         configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders
@@ -144,7 +148,7 @@ public class ImageDownloader {
     /// Creates a default `URLCache` with common usage parameter values.
     ///
     /// - returns: The default `URLCache` instance.
-    public class func defaultURLCache() -> URLCache {
+    open class func defaultURLCache() -> URLCache {
         return URLCache(
             memoryCapacity: 20 * 1024 * 1024, // 20 MB
             diskCapacity: 150 * 1024 * 1024,  // 150 MB
@@ -199,14 +203,14 @@ public class ImageDownloader {
         self.imageCache = imageCache
     }
 
-    // MARK: - Authentication
+    // MARK: Authentication
 
     /// Associates an HTTP Basic Auth credential with all future download requests.
     ///
     /// - parameter user:        The user.
     /// - parameter password:    The password.
     /// - parameter persistence: The URL credential persistence. `.forSession` by default.
-    public func addAuthentication(
+    open func addAuthentication(
         user: String,
         password: String,
         persistence: URLCredential.Persistence = .forSession)
@@ -218,13 +222,13 @@ public class ImageDownloader {
     /// Associates the specified credential with all future download requests.
     ///
     /// - parameter credential: The credential.
-    public func addAuthentication(usingCredential credential: URLCredential) {
+    open func addAuthentication(usingCredential credential: URLCredential) {
         synchronizationQueue.sync {
             self.credential = credential
         }
     }
 
-    // MARK: - Download
+    // MARK: Download
 
     /// Creates a download request using the internal Alamofire `SessionManager` instance for the specified URL request.
     ///
@@ -252,7 +256,7 @@ public class ImageDownloader {
     /// - returns: The request receipt for the download request if available. `nil` if the image is stored in the image
     ///            cache and the URL request cache policy allows the cache to be used.
     @discardableResult
-    public func download(
+    open func download(
         _ urlRequest: URLRequestConvertible,
         receiptID: String = UUID().uuidString,
         filter: ImageFilter? = nil,
@@ -421,7 +425,7 @@ public class ImageDownloader {
     ///            cache and the URL request cache policy allows the cache to be used, a receipt will not be returned
     ///            for that request.
     @discardableResult
-    public func download(
+    open func download(
         _ urlRequests: [URLRequestConvertible],
         filter: ImageFilter? = nil,
         progress: ProgressHandler? = nil,
@@ -441,7 +445,7 @@ public class ImageDownloader {
     /// will not be called.
     ///
     /// - parameter requestReceipt: The request receipt to cancel.
-    public func cancelRequest(with requestReceipt: RequestReceipt) {
+    open func cancelRequest(with requestReceipt: RequestReceipt) {
         synchronizationQueue.sync {
             let urlID = ImageDownloader.urlIdentifier(for: requestReceipt.request.request!)
             guard let responseHandler = self.responseHandlers[urlID] else { return }
@@ -466,7 +470,7 @@ public class ImageDownloader {
         }
     }
 
-    // MARK: - Internal - Thread-Safe Request Methods
+    // MARK: Internal - Thread-Safe Request Methods
 
     func safelyFetchResponseHandler(withURLIdentifier urlIdentifier: String) -> ResponseHandler? {
         var responseHandler: ResponseHandler?
@@ -509,7 +513,7 @@ public class ImageDownloader {
         }
     }
 
-    // MARK: - Internal - Non Thread-Safe Request Methods
+    // MARK: Internal - Non Thread-Safe Request Methods
 
     func start(_ request: Request) {
         request.resume()


### PR DESCRIPTION
This PR opens up the `AutoPurgingImageCache` and `ImageDownloader` APIs to allow subclassing. I only exposed the core APIs, not all the internals. I don't want to open up the thread-safety properties to subclassing unless someone has a really good use case for doing so.

This change will allow users to override the `imageCacheKey` API in the `AutoPurgingImageCache` to allow subclasses to implement their own logic for determining unique cache keys.

> For more info on this point, see #201.
