### PR TITLE
Support for custom imageResponseSerializer

### DIFF
--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -96,6 +96,9 @@ public class ImageDownloader {
 
     /// The credential used for authenticating each download request.
     public private(set) var credential: URLCredential?
+    
+    /// Response serializer used to convert the image data to UIImage.
+    public var imageResponseSerializer = DataRequest.imageResponseSerializer()
 
     /// The underlying Alamofire `Manager` instance used to handle all download requests.
     public let sessionManager: SessionManager
@@ -314,7 +317,7 @@ public class ImageDownloader {
 
             request.response(
                 queue: self.responseQueue,
-                responseSerializer: DataRequest.imageResponseSerializer(),
+                responseSerializer: imageResponseSerializer,
                 completionHandler: { [weak self] response in
                     guard let strongSelf = self, let request = response.request else { return }
 

--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -292,7 +292,7 @@ extension DataRequest {
 
     // MARK: - Private - Shared Helper Methods
 
-    private class func validateContentType(for request: URLRequest?, response: HTTPURLResponse?) throws {
+    public class func validateContentType(for request: URLRequest?, response: HTTPURLResponse?) throws {
         if let url = request?.url, url.isFileURL { return }
 
         guard let mimeType = response?.mimeType else {


### PR DESCRIPTION
I made as minimal changes as possible to add a way to replace the default `imageResponseSerializer` in `ImageDownloader`. I added `imageResponseSerializer` variable in `ImageDownloader` instead of calling `DataRequest.imageResponseSerializer()` directly to make it possible to use a custom serializer implementation.

`validateContentType` needs to be public to be accessible from the custom `ImageResponseSerializer` implementation (using AlamofireImage as a pod).

With these changes I was able to create my own `ImageResponseSerializer` closure and add animated GIF support to my app. Below is my custom serializer code. `imageWithCachedData` extracts frames from the gif data.

```
let downloader = ImageDownloader(maximumActiveDownloads: 10)

downloader.imageResponseSerializer = DataResponseSerializer { request, response, data, error in
    let result = Request.serializeResponseData(response: response, data: data, error: error)
    guard case let .success(data) = result else { return .failure(result.error!) }

    do {
        try DataRequest.validateContentType(for: request, response: response)

        if let image = UIImage.imageWithCachedData(data) {
            image.af_inflate()
            return .success(image)
        }

        return .failure(AFIError.imageSerializationFailed)
    } catch {
        return .failure(error)
    }
}

UIImageView.af_sharedImageDownloader = downloader
```
