### PR TITLE
Add Embedded Framework instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,44 @@ github "Alamofire/AlamofireImage" ~> 3.1
 
 Run `carthage update` to build the framework and drag the built `AlamofireImage.framework` into your Xcode project.
 
+### Manually
+
+If you prefer not to use either of the aforementioned dependency managers, you can integrate AlamofireImage into your project manually.
+
+#### Embedded Framework
+
+- Open up Terminal, `cd` into your top-level project directory, and run the following command "if" your project is not initialized as a git repository:
+
+  ```bash
+$ git init
+```
+
+- Add AlamofireImage as a git [submodule](http://git-scm.com/docs/git-submodule) by running the following command:
+
+  ```bash
+$ git submodule add https://github.com/Alamofire/AlamofireImage.git
+```
+
+- Open the new `AlamofireImage` folder, and drag the `AlamofireImage.xcodeproj` into the Project Navigator of your application's Xcode project.
+
+    > It should appear nested underneath your application's blue project icon. Whether it is above or below all the other Xcode groups does not matter.
+
+- Select the `AlamofireImage.xcodeproj` in the Project Navigator and verify the deployment target matches that of your application target.
+- Next, select your application project in the Project Navigator (blue project icon) to navigate to the target configuration window and select the application target under the "Targets" heading in the sidebar.
+- In the tab bar at the top of that window, open the "General" panel.
+- Click on the `+` button under the "Embedded Binaries" section.
+- You will see two different `AlamofireImage.xcodeproj` folders each with two different versions of the `AlamofireImage.framework` nested inside a `Products` folder.
+
+    > It does not matter which `Products` folder you choose from, but it does matter whether you choose the top or bottom `AlamofireImage.framework`.
+
+- Select the top `AlamofireImage.framework` for iOS and the bottom one for OS X.
+
+    > You can verify which one you selected by inspecting the build log for your project. The build target for `AlamofireImage` will be listed as either `AlamofireImage iOS`, `AlamofireImage macOS`, `AlamofireImage tvOS` or `AlamofireImage watchOS`.
+
+- And that's it!
+
+  > The `AlamofireImage.framework` is automagically added as a target dependency, linked framework and embedded framework in a copy files build phase which is all you need to build on the simulator and a device.
+
 ---
 
 ## Usage


### PR DESCRIPTION
Embedded Framework (git submodule) instructions added to the README.

I noticed the readme for AlamofireImage was missing the embedded framework (git submodule) instructions. This is working the same as AlamoFire itself so I added it to the README.