### PR TITLE
set image in main queue when image is loaded from cache

### DIFF
--- a/Source/UIImageView+AlamofireImage.swift
+++ b/Source/UIImageView+AlamofireImage.swift
@@ -293,8 +293,10 @@ extension UIImageView {
                     completion?(response)
                 }
             } else {
-                self.image = image
-                completion?(response)
+                DispatchQueue.main.async {
+                    self.image = image
+                    completion?(response)
+                }
             }
 
             return

--- a/Source/UIImageView+AlamofireImage.swift
+++ b/Source/UIImageView+AlamofireImage.swift
@@ -293,7 +293,7 @@ extension UIImageView {
                     completion?(response)
                 }
             } else {
-                DispatchQueue.main.async {
+                DispatchQueue.main.sync {
                     self.image = image
                     completion?(response)
                 }


### PR DESCRIPTION
Issue: if the `af_setImage` function in `UIImageView` is called with same URL for multiple times, image is retrieved from cache and directly set without dispatching into main queue. 

Solution: Dispatch to the main queue.