### PR TITLE
On disk cache

### DIFF
--- a/AlamofireImage.xcodeproj/project.pbxproj
+++ b/AlamofireImage.xcodeproj/project.pbxproj
@@ -501,6 +501,13 @@
 		4CFB86631CA3656F007CE085 /* UIButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF24CF3C1C253CA000904E85 /* UIButtonTests.swift */; };
 		4CFC0A061AB4FEC90004D0B8 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFC0A051AB4FEC90004D0B8 /* ImageCache.swift */; };
 		4CFC0A091AB52BD90004D0B8 /* ImageFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFC0A081AB52BD90004D0B8 /* ImageFilter.swift */; };
+		5024D49E1F3A3ECA001FDBF1 /* PersistentImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5024D49D1F3A3ECA001FDBF1 /* PersistentImageCache.swift */; };
+		5024D4A31F3A3EF4001FDBF1 /* PersistentImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5024D49D1F3A3ECA001FDBF1 /* PersistentImageCache.swift */; };
+		5024D4A41F3A3EF5001FDBF1 /* PersistentImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5024D49D1F3A3ECA001FDBF1 /* PersistentImageCache.swift */; };
+		5024D4A51F3A3EF6001FDBF1 /* PersistentImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5024D49D1F3A3ECA001FDBF1 /* PersistentImageCache.swift */; };
+		5024D4A81F3A425A001FDBF1 /* PersistentImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5024D4A61F3A4247001FDBF1 /* PersistentImageCacheTests.swift */; };
+		5024D4A91F3A425B001FDBF1 /* PersistentImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5024D4A61F3A4247001FDBF1 /* PersistentImageCacheTests.swift */; };
+		5024D4AA1F3A425C001FDBF1 /* PersistentImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5024D4A61F3A4247001FDBF1 /* PersistentImageCacheTests.swift */; };
 		CF24CF421C253CB100904E85 /* UIButton+AlamofireImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF24CF411C253CB100904E85 /* UIButton+AlamofireImage.swift */; };
 		CF24CF461C253D4F00904E85 /* UIButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF24CF3C1C253CA000904E85 /* UIButtonTests.swift */; };
 /* End PBXBuildFile section */
@@ -778,6 +785,8 @@
 		4CEBB53F1B93C622001391DE /* ImageCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheTests.swift; sourceTree = "<group>"; };
 		4CFC0A051AB4FEC90004D0B8 /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		4CFC0A081AB52BD90004D0B8 /* ImageFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageFilter.swift; sourceTree = "<group>"; };
+		5024D49D1F3A3ECA001FDBF1 /* PersistentImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistentImageCache.swift; sourceTree = "<group>"; };
+		5024D4A61F3A4247001FDBF1 /* PersistentImageCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistentImageCacheTests.swift; sourceTree = "<group>"; };
 		CF24CF3C1C253CA000904E85 /* UIButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonTests.swift; sourceTree = "<group>"; };
 		CF24CF411C253CB100904E85 /* UIButton+AlamofireImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIButton+AlamofireImage.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -899,6 +908,7 @@
 				4CD5BCE91D7F9D1E0055E232 /* AFIError.swift */,
 				4C8290791B927CE6005E24C8 /* Image.swift */,
 				4CFC0A051AB4FEC90004D0B8 /* ImageCache.swift */,
+				5024D49D1F3A3ECA001FDBF1 /* PersistentImageCache.swift */,
 				4C96A4771AAE9488008AE0B6 /* ImageDownloader.swift */,
 				4CFC0A081AB52BD90004D0B8 /* ImageFilter.swift */,
 				4C5D84571AAD958A00A42375 /* Extensions */,
@@ -1192,6 +1202,7 @@
 			children = (
 				4C1624841AABE8E600A0385D /* BaseTestCase.swift */,
 				4CEBB53F1B93C622001391DE /* ImageCacheTests.swift */,
+				5024D4A61F3A4247001FDBF1 /* PersistentImageCacheTests.swift */,
 				4C5874851B93F81800407E58 /* ImageDownloaderTests.swift */,
 				4C5872C91B93DEAC00407E58 /* ImageFilterTests.swift */,
 				4C0897EA1B93BC0D005125D9 /* RequestTests.swift */,
@@ -2024,6 +2035,7 @@
 				4C16B3A41BA93AB700A66EF0 /* Request+AlamofireImage.swift in Sources */,
 				4C16B3A51BA93AB700A66EF0 /* UIImage+AlamofireImage.swift in Sources */,
 				4C16B3A31BA93AB700A66EF0 /* ImageFilter.swift in Sources */,
+				5024D4A41F3A3EF5001FDBF1 /* PersistentImageCache.swift in Sources */,
 				4C16B3A21BA93AB700A66EF0 /* ImageDownloader.swift in Sources */,
 				4C16B3A01BA93AB700A66EF0 /* Image.swift in Sources */,
 			);
@@ -2040,6 +2052,7 @@
 				4C16B3AE1BA93ADB00A66EF0 /* UIImage+AlamofireImageTests.swift in Sources */,
 				4C16B3AA1BA93ADB00A66EF0 /* ImageFilterTests.swift in Sources */,
 				4C16B3A71BA93ADB00A66EF0 /* BaseTestCase.swift in Sources */,
+				5024D4AA1F3A425C001FDBF1 /* PersistentImageCacheTests.swift in Sources */,
 				4C16B3AD1BA93ADB00A66EF0 /* UIImageViewTests.swift in Sources */,
 				4C16B3A91BA93ADB00A66EF0 /* ImageDownloaderTests.swift in Sources */,
 				4C16B3AC1BA93ADB00A66EF0 /* UIImageTests.swift in Sources */,
@@ -2057,6 +2070,7 @@
 				4C4D4ECE1B9297BB00C96855 /* Request+AlamofireImage.swift in Sources */,
 				4C4D4ECF1B9297BB00C96855 /* UIImage+AlamofireImage.swift in Sources */,
 				4C4D4ECD1B9297BB00C96855 /* ImageFilter.swift in Sources */,
+				5024D4A51F3A3EF6001FDBF1 /* PersistentImageCache.swift in Sources */,
 				4C4D4ECC1B9297BB00C96855 /* ImageDownloader.swift in Sources */,
 				4C4D4ECA1B9297BB00C96855 /* Image.swift in Sources */,
 			);
@@ -2073,6 +2087,7 @@
 				CF24CF421C253CB100904E85 /* UIButton+AlamofireImage.swift in Sources */,
 				4C78EA721AACD28C002C0569 /* UIImageView+AlamofireImage.swift in Sources */,
 				4C5308501AB561BF0051DBAC /* UIImage+AlamofireImage.swift in Sources */,
+				5024D49E1F3A3ECA001FDBF1 /* PersistentImageCache.swift in Sources */,
 				4CFC0A061AB4FEC90004D0B8 /* ImageCache.swift in Sources */,
 				4CE611551AABC8D900D35044 /* Request+AlamofireImage.swift in Sources */,
 			);
@@ -2089,6 +2104,7 @@
 				4C5872CA1B93DEAC00407E58 /* ImageFilterTests.swift in Sources */,
 				4CEBB5401B93C622001391DE /* ImageCacheTests.swift in Sources */,
 				4C0893EC1B936A7A005125D9 /* UIImage+AlamofireImageTests.swift in Sources */,
+				5024D4A81F3A425A001FDBF1 /* PersistentImageCacheTests.swift in Sources */,
 				4C1624851AABE8E600A0385D /* BaseTestCase.swift in Sources */,
 				4C0893F51B937404005125D9 /* UIImageTests.swift in Sources */,
 				4C5874861B93F81800407E58 /* ImageDownloaderTests.swift in Sources */,
@@ -2106,6 +2122,7 @@
 				4C82907C1B927D13005E24C8 /* ImageDownloader.swift in Sources */,
 				4CE611561AABC8D900D35044 /* Request+AlamofireImage.swift in Sources */,
 				4CD5BCEB1D7F9D1E0055E232 /* AFIError.swift in Sources */,
+				5024D4A31F3A3EF4001FDBF1 /* PersistentImageCache.swift in Sources */,
 				4C86C10C1DA0B3110032ECC3 /* UIImage+AlamofireImage.swift in Sources */,
 				4C86C10B1DA0B30E0032ECC3 /* UIButton+AlamofireImage.swift in Sources */,
 			);
@@ -2122,6 +2139,7 @@
 				4C1624861AABE8E600A0385D /* BaseTestCase.swift in Sources */,
 				4CEBB5411B93C622001391DE /* ImageCacheTests.swift in Sources */,
 				4C86C1121DA0B3400032ECC3 /* UIImageViewTests.swift in Sources */,
+				5024D4A91F3A425B001FDBF1 /* PersistentImageCacheTests.swift in Sources */,
 				4C5874871B93F81800407E58 /* ImageDownloaderTests.swift in Sources */,
 				4C86C1131DA0B3440032ECC3 /* UIImage+AlamofireImageTests.swift in Sources */,
 				4C0897EC1B93BC0D005125D9 /* RequestTests.swift in Sources */,

--- a/AlamofireImage.xcodeproj/xcshareddata/xcschemes/AlamofireImage iOS.xcscheme
+++ b/AlamofireImage.xcodeproj/xcshareddata/xcschemes/AlamofireImage iOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0900"
-   version = "1.3">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -41,7 +41,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -70,7 +71,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -37,6 +37,7 @@ import Cocoa
 public protocol ImageCache {
     /// Adds the image to the cache with the given identifier.
     func add(_ image: Image, withIdentifier identifier: String)
+    func add(_ image: Image, withIdentifier identifier: String, andCompletion completion: @escaping ()->())
 
     /// Removes the image from the cache matching the given identifier.
     func removeImage(withIdentifier identifier: String) -> Bool
@@ -176,11 +177,16 @@ open class AutoPurgingImageCache: ImageRequestCache {
         add(image, withIdentifier: requestIdentifier)
     }
 
+    open func add(_ image: Image, withIdentifier identifier: String) {
+        self.add(image, withIdentifier: identifier) { }
+    }
+    
     /// Adds the image to the cache with the given identifier.
     ///
     /// - parameter image:      The image to add to the cache.
     /// - parameter identifier: The identifier to use to uniquely identify the image.
-    open func add(_ image: Image, withIdentifier identifier: String) {
+    /// - parameter completion: The code to be executed when the add operation is accomplished.
+    open func add(_ image: Image, withIdentifier identifier: String, andCompletion completion: @escaping ()->()) {
         synchronizationQueue.async(flags: [.barrier]) {
             let cachedImage = CachedImage(image, identifier: identifier)
 
@@ -218,6 +224,10 @@ open class AutoPurgingImageCache: ImageRequestCache {
 
                 self.currentMemoryUsage -= bytesPurged
             }
+        }
+        
+        synchronizationQueue.async(flags: [.barrier]) {
+            completion()
         }
     }
 

--- a/Source/PersistentImageCache.swift
+++ b/Source/PersistentImageCache.swift
@@ -332,8 +332,10 @@ open class PersistentAutoPurgingImageCache: AutoPurgingImageCache, PersistentIma
             if image == nil,
                 let data = try? Data(contentsOf: URL(fileURLWithPath: path)) {
                 
-                #if os(iOS) || os(tvOS) || os(watchOS)
+                #if os(iOS) || os(tvOS)
                     image = UIImage(data: data, scale: UIScreen.main.scale)
+                #elseif os(watchOS)
+                    image = UIImage(data: data, scale: 1)
                 #elseif os(macOS)
                     image = NSImage(data: data)
                 #endif

--- a/Source/PersistentImageCache.swift
+++ b/Source/PersistentImageCache.swift
@@ -1,0 +1,117 @@
+//
+//  PersistentImageCache.swift
+//  AlamofireImage
+//
+//  Created by Giuseppe Lanza on 08/08/2017.
+//  Copyright © 2017 Alamofire. All rights reserved.
+//
+
+import Foundation
+
+#if os(iOS) || os(tvOS) || os(watchOS)
+    import UIKit
+#elseif os(macOS)
+    import Cocoa
+#endif
+
+public protocol PersistentImageCache: ImageCache {
+    var defaultTimeToLive: TimeInterval { get set }
+    
+    func remainingLifeForImage(withIdentifier identifier: String) -> TimeInterval?
+    
+    func add(_ image: Image, withIdentifier identifier: String, andTimeToLive timeToLive: TimeInterval)
+    func add(_ image: Image, withIdentifier identifier: String, andTimeToLive timeToLive: TimeInterval,  withCompletion completion: @escaping ()->())
+}
+
+open class PersistentAutoPurgingImageCache: AutoPurgingImageCache, PersistentImageCache {
+    public var defaultTimeToLive: TimeInterval
+    
+    private let synchronizationQueue: DispatchQueue
+    private let fileManager = FileManager()
+    
+    private let persistencePath: String
+    
+    public init(memoryCapacity: UInt64 = 100_000_000, preferredMemoryUsageAfterPurge: UInt64 = 60_000_000, defaultTimeToLive: TimeInterval = 7 * 24 * 3600, persistencePath: String = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first!) {
+        self.defaultTimeToLive = defaultTimeToLive
+        
+        var isDir: ObjCBool = false
+        precondition(FileManager.default.fileExists(atPath: persistencePath, isDirectory: &isDir) && isDir.boolValue, "The persistence path should exist, and it should be a directory")
+        self.persistencePath = persistencePath
+        
+        self.synchronizationQueue = {
+            let name = String(format: "org.alamofire.persistentautopurgingimagecache-%08x%08x", arc4random(), arc4random())
+            return DispatchQueue(label: name, attributes: .concurrent)
+        }()
+
+        super.init(memoryCapacity: memoryCapacity, preferredMemoryUsageAfterPurge: preferredMemoryUsageAfterPurge)
+    }
+    
+    public func remainingLifeForImage(withIdentifier identifier: String) -> TimeInterval? {
+        let path = self.pathForResource(withIdentifier: identifier)
+        guard fileManager.fileExists(atPath: path) else { return nil }
+        
+        var expiration: TimeInterval = 0
+        getxattr(path, "org.alamofire.persistentautopurgingimagecache-expiration", &expiration, MemoryLayout<TimeInterval>.size, 0, 0)
+        
+        return expiration - NSDate().timeIntervalSince1970
+    }
+    
+    open override func add(_ image: Image, withIdentifier identifier: String) {
+        self.add(image, withIdentifier: identifier, andTimeToLive: defaultTimeToLive)
+    }
+    
+    open override func add(_ image: Image, withIdentifier identifier: String, andCompletion completion: @escaping () -> ()) {
+        self.add(image, withIdentifier: identifier, andTimeToLive: defaultTimeToLive, withCompletion: completion)
+    }
+    
+    open func add(_ image: Image, withIdentifier identifier: String, andTimeToLive timeToLive: TimeInterval) {
+        self.add(image, withIdentifier: identifier, andTimeToLive: timeToLive, withCompletion: ({ }))
+    }
+    
+    open func add(_ image: Image, withIdentifier identifier: String, andTimeToLive timeToLive: TimeInterval, withCompletion completion: @escaping ()->()) {
+        synchronizationQueue.async(flags: [.barrier]) {
+            let path = self.pathForResource(withIdentifier: identifier)
+
+            defer {
+                //We want to update the time to live if the image was added again.
+                if self.fileManager.fileExists(atPath: path) {
+                    var expiration = Date().addingTimeInterval(timeToLive).timeIntervalSince1970
+                    
+                    setxattr(path, "org.alamofire.persistentautopurgingimagecache-expiration", &expiration, MemoryLayout<TimeInterval>.size, 0, 0)
+
+                }
+            }
+            
+            guard !self.fileManager.fileExists(atPath: path) else {
+                return
+            }
+            
+            #if os(iOS) || os(tvOS) || os(watchOS)
+                guard let data = UIImageJPEGRepresentation(image, 1.0) as NSData? else {
+                    return
+                }
+            #elseif os(macOS)
+                guard let imageData = image.tiffRepresentation,
+                    let rep = NSBitmapImageRep(data: imageData),
+                    let data = rep.representation(using: .PNG, properties: [NSImageCompressionFactor: 1.0]) as NSData? else {
+                    return
+                }
+            #endif
+            
+            try? data.write(toFile: path, options: .atomic)
+        }
+        
+        //super add uses a different synchronization queue, therefore to synchronize the completion at the end of the add 
+        //operation we need to schedule on our synchronization queue the completion, when the super add is finished. The 
+        //barrier flags will ensure us that there are no data race condition, bbecause if the previous block is still running, 
+        //the barrier will prevent the completion block to bbe executed. If it is no longer running, then it means that we are 
+        //ready to complete.
+        super.add(image, withIdentifier: identifier) {
+            self.synchronizationQueue.async(flags: [.barrier], execute: completion)
+        }
+    }
+
+    private func pathForResource(withIdentifier identifier: String) -> String {
+        return (self.persistencePath as NSString).appendingPathComponent(identifier)
+    }
+}

--- a/Source/PersistentImageCache.swift
+++ b/Source/PersistentImageCache.swift
@@ -14,16 +14,32 @@ import Foundation
     import Cocoa
 #endif
 
-public protocol PersistentImageCache: ImageCache {
+// MARK: PersistentImageCache
+
+public protocol PersistentImageCache: ImageRequestCache {
     var defaultTimeToLive: TimeInterval { get set }
     
     func remainingLifeForImage(withIdentifier identifier: String) -> TimeInterval?
-    
+    func remainingLifeForImage(for request: URLRequest, withIdentifier identifier: String) -> TimeInterval?
+
     func add(_ image: Image, withIdentifier identifier: String, andTimeToLive timeToLive: TimeInterval)
-    func add(_ image: Image, withIdentifier identifier: String, andTimeToLive timeToLive: TimeInterval,  withCompletion completion: @escaping ()->())
+    func add(_ image: Image, withIdentifier identifier: String, andTimeToLive timeToLive: TimeInterval, withCompletion completion: @escaping ()->())
+    
+    func add(_ image: Image, for request: URLRequest, withIdentifier identifier: String?, andTimeToLive timeToLive: TimeInterval)
+    func add(_ image: Image, for request: URLRequest, withIdentifier identifier: String?, andTimeToLive timeToLive: TimeInterval, withCompletion completion: @escaping ()->())
+    
+    func removeAllImagesInMemory() -> Bool
+    
+    func cleanup() -> Bool
 }
 
+// MARK: -
+
 open class PersistentAutoPurgingImageCache: AutoPurgingImageCache, PersistentImageCache {
+    
+    // MARK: Properties
+    
+    ///The default time to live for any new added image.
     public var defaultTimeToLive: TimeInterval
     
     private let synchronizationQueue: DispatchQueue
@@ -31,6 +47,20 @@ open class PersistentAutoPurgingImageCache: AutoPurgingImageCache, PersistentIma
     
     private let persistencePath: String
     
+    private var cleanupTimer: Timer?
+    
+    // MARK: Initialization
+
+    ///Initializes the `PersistentAutoPurgingImageCache` instance with the given memory capacity, preferred memory usage after purge limit, 
+    ///default time to live and cache path.
+    ///
+    /// Please note, the memory capacity must always be greater than or equal to the preferred memory usage after purge.
+    /// - parameter memoryCapacity:                 The total memory capacity of the cache in bytes. `100 MB` by default.
+    /// - parameter preferredMemoryUsageAfterPurge: The preferred memory usage after purge in bytes. `60 MB` by default.
+    /// - parameter defaultTimeToLive:              The default time to live for any new added image
+    /// - parameter persistencePath:                The cahce folder path.
+    ///
+    /// - returns: The new `AutoPurgingImageCache` instance.
     public init(memoryCapacity: UInt64 = 100_000_000, preferredMemoryUsageAfterPurge: UInt64 = 60_000_000, defaultTimeToLive: TimeInterval = 7 * 24 * 3600, persistencePath: String = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first!) {
         self.defaultTimeToLive = defaultTimeToLive
         
@@ -42,43 +72,69 @@ open class PersistentAutoPurgingImageCache: AutoPurgingImageCache, PersistentIma
             let name = String(format: "org.alamofire.persistentautopurgingimagecache-%08x%08x", arc4random(), arc4random())
             return DispatchQueue(label: name, attributes: .concurrent)
         }()
-
+        
         super.init(memoryCapacity: memoryCapacity, preferredMemoryUsageAfterPurge: preferredMemoryUsageAfterPurge)
+        
+        #if os(iOS) || os(tvOS)
+            //Remove the previous observer set by super init
+            NotificationCenter.default.removeObserver(self, name: Notification.Name.UIApplicationDidReceiveMemoryWarning, object: nil)
+            
+            //And add the custom new one to avoid that memory warning purge disk cache as well
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(PersistentAutoPurgingImageCache.removeAllImagesInMemory),
+                name: Notification.Name.UIApplicationDidReceiveMemoryWarning,
+                object: nil
+            )
+        #endif
+        
+        cleanup()
     }
     
-    public func remainingLifeForImage(withIdentifier identifier: String) -> TimeInterval? {
-        let path = self.pathForResource(withIdentifier: identifier)
-        guard fileManager.fileExists(atPath: path) else { return nil }
-        
-        var expiration: TimeInterval = 0
-        getxattr(path, "org.alamofire.persistentautopurgingimagecache-expiration", &expiration, MemoryLayout<TimeInterval>.size, 0, 0)
-        
-        return expiration - NSDate().timeIntervalSince1970
-    }
+    // MARK: Add Image to Cache
     
+    /// Adds the image to the cache with the given identifier.
+    ///
+    /// - parameter image:      The image to add to the cache.
+    /// - parameter identifier: The identifier to use to uniquely identify the image.
     open override func add(_ image: Image, withIdentifier identifier: String) {
         self.add(image, withIdentifier: identifier, andTimeToLive: defaultTimeToLive)
     }
     
+    /// Adds the image to the cache with the given identifier.
+    ///
+    /// - parameter image:      The image to add to the cache.
+    /// - parameter identifier: The identifier to use to uniquely identify the image.
+    /// - parameter completion: The code to be executed when the add operation is accomplished.
     open override func add(_ image: Image, withIdentifier identifier: String, andCompletion completion: @escaping () -> ()) {
         self.add(image, withIdentifier: identifier, andTimeToLive: defaultTimeToLive, withCompletion: completion)
     }
     
+    /// Adds the image to the cache with the given identifier.
+    ///
+    /// - parameter image:      The image to add to the cache.
+    /// - parameter identifier: The identifier to use to uniquely identify the image.
+    /// - parameter timeToLive: The amount of seconds of lif granted to the cached image on disk.
     open func add(_ image: Image, withIdentifier identifier: String, andTimeToLive timeToLive: TimeInterval) {
         self.add(image, withIdentifier: identifier, andTimeToLive: timeToLive, withCompletion: ({ }))
     }
     
+    /// Adds the image to the cache with the given identifier.
+    ///
+    /// - parameter image:      The image to add to the cache.
+    /// - parameter identifier: The identifier to use to uniquely identify the image.
+    /// - parameter timeToLive: The amount of seconds of lif granted to the cached image on disk.
+    /// - parameter completion: The code to be executed when the add operation is accomplished.
     open func add(_ image: Image, withIdentifier identifier: String, andTimeToLive timeToLive: TimeInterval, withCompletion completion: @escaping ()->()) {
         synchronizationQueue.async(flags: [.barrier]) {
             let path = self.pathForResource(withIdentifier: identifier)
-
+            
             defer {
                 //We want to update the time to live if the image was added again.
                 if self.fileManager.fileExists(atPath: path) {
                     var expiration = Date().addingTimeInterval(timeToLive).timeIntervalSince1970
                     
                     setxattr(path, "org.alamofire.persistentautopurgingimagecache-expiration", &expiration, MemoryLayout<TimeInterval>.size, 0, 0)
-
                 }
             }
             
@@ -93,25 +149,346 @@ open class PersistentAutoPurgingImageCache: AutoPurgingImageCache, PersistentIma
             #elseif os(macOS)
                 guard let imageData = image.tiffRepresentation,
                     let rep = NSBitmapImageRep(data: imageData),
-                    let data = rep.representation(using: .PNG, properties: [NSImageCompressionFactor: 1.0]) as NSData? else {
-                    return
+                    let data = rep.representation(using: .JPEG, properties: [NSImageCompressionFactor: 1.0]) as NSData? else {
+                        return
                 }
             #endif
             
             try? data.write(toFile: path, options: .atomic)
+            self.scheduleTimer()
         }
         
-        //super add uses a different synchronization queue, therefore to synchronize the completion at the end of the add 
-        //operation we need to schedule on our synchronization queue the completion, when the super add is finished. The 
-        //barrier flags will ensure us that there are no data race condition, bbecause if the previous block is still running, 
-        //the barrier will prevent the completion block to bbe executed. If it is no longer running, then it means that we are 
+        //super add uses a different synchronization queue, therefore to synchronize the completion at the end of the add
+        //operation we need to schedule on our synchronization queue the completion, when the super add is finished. The
+        //barrier flags will ensure us that there are no data race condition, bbecause if the previous block is still running,
+        //the barrier will prevent the completion block to bbe executed. If it is no longer running, then it means that we are
         //ready to complete.
         super.add(image, withIdentifier: identifier) {
             self.synchronizationQueue.async(flags: [.barrier], execute: completion)
         }
     }
+    
+    /// Adds the image to the cache using an identifier created from the request and optional identifier.
+    ///
+    /// - parameter image:      The image to add to the cache.
+    /// - parameter request:    The request used to generate the image's unique identifier.
+    /// - parameter identifier: The additional identifier to append to the image's unique identifier.
+    open override func add(_ image: Image, for request: URLRequest, withIdentifier identifier: String?) {
+        add(image, for: request, withIdentifier: identifier, andTimeToLive: defaultTimeToLive)
+    }
+    
+    /// Adds the image to the cache using an identifier created from the request and optional identifier.
+    ///
+    /// - parameter image:      The image to add to the cache.
+    /// - parameter request:    The request used to generate the image's unique identifier.
+    /// - parameter identifier: The additional identifier to append to the image's unique identifier.
+    /// - parameter completion: The block to be executed at the end of the add operation.
+    open override func add(_ image: Image, for request: URLRequest, withIdentifier identifier: String?, andCompletion completion: @escaping () -> ()) {
+        add(image, for: request, withIdentifier: identifier, andTimeToLive: defaultTimeToLive, withCompletion: completion)
+    }
+    
+    /// Adds the image to the cache using an identifier created from the request and optional identifier.
+    ///
+    /// - parameter image:      The image to add to the cache.
+    /// - parameter request:    The request used to generate the image's unique identifier.
+    /// - parameter identifier: The additional identifier to append to the image's unique identifier.
+    /// - parameter timeToLive: The amount of seconds of lif granted to the cached image on disk.
+    open func add(_ image: Image, for request: URLRequest, withIdentifier identifier: String?, andTimeToLive timeToLive: TimeInterval) {
+        let requestIdentifier = imageCacheKey(for: request, withIdentifier: identifier)
+        add(image, withIdentifier: requestIdentifier, andTimeToLive: timeToLive)
+    }
+    
+    /// Adds the image to the cache using an identifier created from the request and optional identifier.
+    ///
+    /// - parameter image:      The image to add to the cache.
+    /// - parameter request:    The request used to generate the image's unique identifier.
+    /// - parameter identifier: The additional identifier to append to the image's unique identifier.
+    /// - parameter timeToLive: The amount of seconds of lif granted to the cached image on disk.
+    /// - parameter completion: The block to be executed at the end of the add operation.
+    open func add(_ image: Image, for request: URLRequest, withIdentifier identifier: String?, andTimeToLive timeToLive: TimeInterval, withCompletion completion: @escaping ()->()) {
+        let requestIdentifier = imageCacheKey(for: request, withIdentifier: identifier)
+        add(image, withIdentifier: requestIdentifier, andTimeToLive: timeToLive, withCompletion: completion)
+    }
+    
+    // MARK: Remove Image from Cache
 
+    /// Removes the image from the cache matching the given identifier.
+    ///
+    /// - parameter identifier: The unique identifier for the image.
+    ///
+    /// - returns: `true` if the image was removed, `false` otherwise.
+    @discardableResult
+    open override func removeImage(withIdentifier identifier: String) -> Bool {
+        var diskRemoved = false
+        synchronizationQueue.sync {
+            let path = pathForResource(withIdentifier: identifier)
+            do {
+                try self.fileManager.removeItem(atPath: path)
+                diskRemoved = true
+            } catch let error {
+                print("ERROR Removing file: ", error)
+            }
+            
+            self.scheduleTimer()
+        }
+        
+        super.removeImage(withIdentifier: identifier)
+        return diskRemoved
+    }
+    
+    /// Removes the image from the cache using an identifier created from the request and optional identifier.
+    ///
+    /// - parameter request:    The request used to generate the image's unique identifier.
+    /// - parameter identifier: The additional identifier to append to the image's unique identifier.
+    ///
+    /// - returns: `true` if the image was removed, `false` otherwise.
+    open override func removeImage(for request: URLRequest, withIdentifier identifier: String?) -> Bool {
+        let requestIdentifier = imageCacheKey(for: request, withIdentifier: identifier)
+        return removeImage(withIdentifier: requestIdentifier)
+    }
+    
+    /// Removes all images from the cache created from the request.
+    ///
+    /// - parameter request: The request used to generate the image's unique identifier.
+    ///
+    /// - returns: `true` if any images were removed, `false` otherwise.
+    @discardableResult
+    open override func removeImages(matching request: URLRequest) -> Bool {
+        let requestIdentifier = imageCacheKey(for: request, withIdentifier: nil).addingPercentEncoding(withAllowedCharacters: .letters)!
+        var removed = false
+        
+        synchronizationQueue.sync {
+            let files = self.cachedFileNames().filter { $0.hasPrefix(requestIdentifier) }
+            removed = self.removeFiles(matchingFileNames: files)
+            
+            self.scheduleTimer()
+        }
+        
+        super.removeImages(matching: request)
+        
+        return removed
+    }
+    
+    /// Removes all images stored in the memory cache.
+    ///
+    /// - returns: `true` if images were removed from the memory cache, `false` otherwise.
+    @discardableResult @objc
+    open func removeAllImagesInMemory() -> Bool {
+        return super.removeAllImages()
+    }
+    
+    /// Removes all images stored in the cache.
+    ///
+    /// - returns: `true` if images were removed from the cache, `false` otherwise.
+    @discardableResult
+    open override func removeAllImages() -> Bool {
+        var removed = false
+        
+        synchronizationQueue.sync {
+            let files = self.cachedFileNames()
+            removed = self.removeFiles(matchingFileNames: files)
+            
+            self.scheduleTimer()
+        }
+        
+        let _ = super.removeAllImages()
+        return removed
+    }
+    
+    ///Remove the images with specified file names.
+    ///
+    /// - parameter fileNames: The names of the files you wish to remove from the disk cache
+    ///
+    /// - returns: `true` if images were removed from the disk cache, `false` otherwise.
+    private func removeFiles(matchingFileNames fileNames: [String]) -> Bool {
+        guard fileNames.count > 0 else { return false }
+        
+        //Let's assume removed true
+        var removed = true
+        for fileName in fileNames {
+            let path = pathForResource(withFileName: fileName)
+            do {
+                try fileManager.removeItem(atPath: path)
+            } catch let error {
+                print("ERROR Removing file: ", error)
+                //removed must be marked as false even if the failure is related to just one file
+                removed = false
+            }
+        }
+        return removed
+    }
+    
+    // MARK: Fetch Image from Cache
+    
+    /// Returns the image in the cache associated with the given identifier.
+    ///
+    /// - parameter identifier: The unique identifier for the image.
+    ///
+    /// - returns: The image if it is stored in the cache, `nil` otherwise.
+    open override func image(withIdentifier identifier: String) -> Image? {
+        var image = super.image(withIdentifier: identifier)
+        synchronizationQueue.sync {
+            let path = self.pathForResource(withIdentifier: identifier)
+            if image == nil,
+                let data = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                
+                #if os(iOS) || os(tvOS) || os(watchOS)
+                    image = UIImage(data: data, scale: UIScreen.main.scale)
+                #elseif os(macOS)
+                    image = NSImage(data: data)
+                #endif
+                
+                if let diskCachedImage = image {
+                    //if requested the image must be back in memory for future access.
+                    super.add(diskCachedImage, withIdentifier: identifier)
+                }
+            }
+        }
+        return image
+    }
+    
+    /// Returns the image from the cache associated with an identifier created from the request and optional identifier.
+    ///
+    /// - parameter request:    The request used to generate the image's unique identifier.
+    /// - parameter identifier: The additional identifier to append to the image's unique identifier.
+    ///
+    /// - returns: The image if it is stored in the cache, `nil` otherwise.
+    open override func image(for request: URLRequest, withIdentifier identifier: String?) -> Image? {
+        let requestIdentifier = imageCacheKey(for: request, withIdentifier: identifier)
+        return image(withIdentifier: requestIdentifier)
+    }
+
+    // MARK: Cache life management
+    ///Returns the remaining life time for the cached image with the specified identifier in seconds, or nil if the image with the specified
+    ///identifier is not cached.
+    ///
+    /// - parameter request:    The request used to generate the image's unique identifier.
+    /// - parameter identifier: The additional identifier to append to the image's unique identifier.
+    ///
+    /// - returns: The life time in seconds or nil if there is no cached image for the specified identifier
+    public func remainingLifeForImage(for request: URLRequest, withIdentifier identifier: String) -> TimeInterval? {
+        let requestIdentifier = imageCacheKey(for: request, withIdentifier: identifier)
+        return remainingLifeForImage(withIdentifier: requestIdentifier)
+    }
+    
+    ///Returns the remaining life time for the cached image with the specified identifier in seconds, or nil if the image with the specified
+    ///identifier is not cached.
+    ///
+    /// - parameter identifier: The identifier for the cached image.
+    ///
+    /// - returns: The life time in seconds or nil if there is no cached image for the specified identifier
+    public func remainingLifeForImage(withIdentifier identifier: String) -> TimeInterval? {
+        let path = self.pathForResource(withIdentifier: identifier)
+        guard fileManager.fileExists(atPath: path) else { return nil }
+        
+        var expiration: TimeInterval = 0
+        getxattr(path, "org.alamofire.persistentautopurgingimagecache-expiration", &expiration, MemoryLayout<TimeInterval>.size, 0, 0)
+        
+        return expiration - NSDate().timeIntervalSince1970
+    }
+    
+    ///Clean the cache folder by deleting files with remaining life < 0. All memory instance of the removed image will be removed too from cache.
+    ///
+    ///- returns: True if at least one file was deleted from disk.
+    @objc @discardableResult
+    open func cleanup() -> Bool {
+        var removedFiles = false
+        synchronizationQueue.sync {
+            let files = self.cachedFileNames()
+            
+            for fileName in files {
+                let identifier = identifierFromFileName(fileName)
+                guard let life = remainingLifeForImage(withIdentifier: identifier),
+                    life <= 0 else {
+                        continue
+                }
+                
+                let path = self.pathForResource(withFileName: fileName)
+                if let _ = try? self.fileManager.removeItem(atPath: path) {
+                    //The image must be purged also from memory
+                    super.removeImage(withIdentifier: identifier)
+                    removedFiles = true
+                }
+            }
+            
+            self.scheduleTimer()
+        }
+        return removedFiles
+    }
+    
+    ///Schedule a timer for the closest expiration date. The timer will trigger the *cleanup* method. If the closest expiration date is in the past
+    ///the timer will be scheduled for the next closest expiration date in the future.
+    private func scheduleTimer() {
+        synchronizationQueue.async(flags: [.barrier]) {
+            if let timer = self.cleanupTimer,
+                timer.isValid {
+                timer.invalidate()
+            }
+            self.cleanupTimer = nil
+            
+            let remainingTimes = self.cachedIdentifiers()
+                .flatMap(self.remainingLifeForImage)
+                .sorted(by: >)
+            
+            guard let closestRemainingTime = remainingTimes.first(where: { $0 > 0 }) else {
+                return
+            }
+            
+            let fireDate = Date().addingTimeInterval(closestRemainingTime)
+            
+            self.cleanupTimer = Timer(fireAt: fireDate, interval: 0, target: self, selector: #selector(self.cleanup), userInfo: nil, repeats: false)
+            RunLoop.main.add(self.cleanupTimer!, forMode: .commonModes)
+        }
+    }
+
+    // MARK: Utility methods
+    
+    ///Returns the path for a resource having the specified identifier
+    ///
+    /// - warning: This method will not check the existence of the resource. It will simply compute the path for the specified identifier.
+    /// - parameter identifier:  The identifier for the resource you want the path of.
+    ///
+    /// - returns: The path for the resource with the specified *identifier*.
     private func pathForResource(withIdentifier identifier: String) -> String {
-        return (self.persistencePath as NSString).appendingPathComponent(identifier)
+        return pathForResource(withFileName: identifier.addingPercentEncoding(withAllowedCharacters: .letters)! + ".afcache")
+    }
+    
+    ///Returns the path for a resource having the specified file name.
+    ///
+    /// - warning: This method will not check the existence of the resource. It will simply compute the path for the specified file name.
+    /// - parameter fileName: The file name for the resource you want the path of.
+    ///
+    /// - returns: The path for the resource with the specified *fileName*.
+    private func pathForResource(withFileName fileName: String) -> String {
+        return (self.persistencePath as NSString).appendingPathComponent(fileName)
+    }
+    
+    ///Returns all the file names for the cached images in the *persistencePath*.
+    ///
+    /// - returns: An array of file names for the cached files in the *persistencePath* folder. If there aren't cached files on disk then
+    ///this method will return empty array.
+    private func cachedFileNames() -> [String] {
+        guard let files = try? fileManager.contentsOfDirectory(atPath: persistencePath).filter({ $0.hasSuffix(".afcache") }) else {
+            return []
+        }
+        
+        return files
+    }
+    
+    ///Returns all the identifiers for the cached images in *persistencePath*.
+    ///
+    /// - returns: An array of identifiers for the cached files in the *persistencePath* folder. If there aren't cached files on disk then
+    ///this method will return empty array.
+    private func cachedIdentifiers() -> [String] {
+        return cachedFileNames().map(identifierFromFileName)
+    }
+    
+    ///Returns the identifier, extracted from the file name.
+    ///
+    /// - parameter fileName: The file name you want the identifier of.
+    ///
+    /// - returns: The identifier extracted from the specified file name.
+    private func identifierFromFileName(_ fileName: String) -> String {
+        return fileName.replacingOccurrences(of: ".afcache", with: "")
     }
 }

--- a/Tests/PersistentImageCacheTests.swift
+++ b/Tests/PersistentImageCacheTests.swift
@@ -42,7 +42,43 @@ class PersistentImageCacheTests: BaseTestCase {
         
         waitForExpectations(timeout: timeout, handler: nil)
 
-        let expectedImagePath = (cachePath as NSString).appendingPathComponent(identifier)
+        let expectedImagePath = (cachePath as NSString).appendingPathComponent(identifier + ".afcache")
+        
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expectedImagePath))
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: expectedImagePath)) else {
+            XCTFail("data should not bbe nil")
+            return
+        }
+        
+        #if os(iOS) || os(tvOS) || os(watchOS)
+            guard let cachedImage = UIImage(data: data, scale: image.scale) else {
+                XCTFail("Image should not be nil")
+                return
+            }
+        #elseif os(macOS)
+            guard let cachedImage = NSImage(data: data) else {
+                XCTFail("Image should not be nil")
+                return
+            }
+        #endif
+        
+        XCTAssertEqual(cachedImage.size, image.size)
+    }
+    
+    func testThatItCanAddImageToCacheWithRequestIdentifier() {
+        let image = self.image(forResource: "unicorn", withExtension: "png")
+        let request = try! URLRequest(url: "https://images.example.com/animals", method: .get)
+        let identifier = "-unicorn"
+        
+        let expectation1 = expectation(description: "image cache should succeed")
+        
+        cache.add(image, for: request, withIdentifier: identifier) {
+            expectation1.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        let expectedImagePath = (cachePath as NSString).appendingPathComponent(cache.imageCacheKey(for: request, withIdentifier: identifier).addingPercentEncoding(withAllowedCharacters: .letters)! + ".afcache")
         
         XCTAssertTrue(FileManager.default.fileExists(atPath: expectedImagePath))
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: expectedImagePath)) else {
@@ -80,7 +116,7 @@ class PersistentImageCacheTests: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
         
         let expectedExpiration = Date().addingTimeInterval(timeToLive).timeIntervalSince1970
-        let path = (cachePath as NSString).appendingPathComponent(identifier)
+        let path = (cachePath as NSString).appendingPathComponent(identifier + ".afcache")
         
         var expiration: TimeInterval = 0
         getxattr(path, "org.alamofire.persistentautopurgingimagecache-expiration", &expiration, MemoryLayout<TimeInterval>.size, 0, 0)
@@ -110,7 +146,136 @@ class PersistentImageCacheTests: BaseTestCase {
     }
     
     func testThatInexistingFilesReturnsNilTimeToLive() {
-        let remainingLife = cache.remainingLifeForImage(withIdentifier: "N/A")
+        let remainingLife = cache.remainingLifeForImage(withIdentifier: "unexisting")
         XCTAssertNil(remainingLife)
+    }
+    
+    func testThatItCanFetchImageEvenIfNotInMemory() {
+        let image = self.image(forResource: "unicorn", withExtension: "png")
+        let identifier = "unicorn"
+        
+        let expectation1 = expectation(description: "image cache should succeed")
+        
+        cache.add(image, withIdentifier: identifier) {
+            expectation1.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        #if os(iOS) || os(tvOS)
+            NotificationCenter.default.post(
+                name: Notification.Name.UIApplicationDidReceiveMemoryWarning,
+                object: nil
+            )
+        #elseif os(macOS)
+            cache.removeAllImagesInMemory()
+        #endif
+        let cachedImage = cache.image(withIdentifier: identifier)
+        
+        XCTAssertNotNil(cachedImage)
+        XCTAssertEqual(cachedImage?.size ?? .zero, image.size)
+    }
+    
+    func testThatItCanRemoveCachedImges() {
+        let image = self.image(forResource: "unicorn", withExtension: "png")
+        let identifier = "unicorn"
+        
+        let expectation1 = expectation(description: "image cache should succeed")
+        
+        cache.add(image, withIdentifier: identifier) {
+            expectation1.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        var cachedImage = cache.image(withIdentifier: identifier)
+        XCTAssertNotNil(cachedImage)
+
+        XCTAssertTrue(cache.removeImage(withIdentifier: identifier))
+        
+        cachedImage = cache.image(withIdentifier: identifier)
+        XCTAssertNil(cachedImage)
+    }
+    
+    func testRemovingUnexistingImages() {
+        let identifier = "unexisting"
+        XCTAssertFalse(cache.removeImage(withIdentifier: identifier))
+    }
+    
+    func testThatItCanRemoveAllCahedImages() {
+        let identifiers = ["apple", "rainbow", "pirate"]
+        
+        for identifier in identifiers {
+            let image = self.image(forResource: identifier, withExtension: "jpg")
+
+            let expectation1 = expectation(description: "image cache should succeed")
+            
+            cache.add(image, withIdentifier: identifier) {
+                expectation1.fulfill()
+            }
+            
+            waitForExpectations(timeout: timeout, handler: nil)
+        }
+        
+        //Proove that the images exist
+        for identifier in identifiers {
+            XCTAssertNotNil(cache.image(withIdentifier: identifier))
+        }
+        
+        XCTAssertTrue(cache.removeAllImages())
+        
+        //Prove that the images do not exist anymore
+        for identifier in identifiers {
+            XCTAssertNil(cache.image(withIdentifier: identifier))
+        }
+    }
+    
+    func testThatItCanCleanupExpiredImages() {
+        let image = self.image(forResource: "unicorn", withExtension: "png")
+        let identifier = "unicorn"
+        
+        let timeToLive: TimeInterval = -60
+        
+        let expectation1 = expectation(description: "image cache should succeed")
+        
+        cache.add(image, withIdentifier: identifier, andTimeToLive: timeToLive) {
+            expectation1.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        //Proove that the image exist
+        XCTAssertNotNil(cache.image(withIdentifier: identifier))
+        
+        cache.cleanup()
+        
+        //Proove that the image does not exist anymore
+        XCTAssertNil(cache.image(withIdentifier: identifier))
+    }
+    
+    func testItCanCleanCacheAutomatically() {
+        let image = self.image(forResource: "unicorn", withExtension: "png")
+        let identifier = "unicorn"
+        
+        let timeToLive: TimeInterval = 5
+        
+        let expectation1 = expectation(description: "image cache should succeed")
+        
+        cache.add(image, withIdentifier: identifier, andTimeToLive: timeToLive) {
+            expectation1.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        //Proove that the image exist
+        XCTAssertNotNil(cache.image(withIdentifier: identifier))
+        
+        let expectation2 = expectation(description: "cache should be cleaned")
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeToLive + 1) {
+            expectation2.fulfill()
+        }
+        
+        waitForExpectations(timeout: 2 * timeToLive, handler: nil)
+
+        //Proove that the image does not exist anymore
+        XCTAssertNil(cache.image(withIdentifier: identifier))
     }
 }

--- a/Tests/PersistentImageCacheTests.swift
+++ b/Tests/PersistentImageCacheTests.swift
@@ -1,0 +1,116 @@
+//
+//  PersistentImageCacheTests.swift
+//  AlamofireImage
+//
+//  Created by Giuseppe Lanza on 08/08/2017.
+//  Copyright © 2017 Alamofire. All rights reserved.
+//
+
+@testable import AlamofireImage
+import Foundation
+import XCTest
+
+
+class PersistentImageCacheTests: BaseTestCase {
+    var cache: PersistentAutoPurgingImageCache!
+    var cachePath: String!
+    
+    override func setUp() {
+        super.setUp()
+        cachePath = (NSTemporaryDirectory() as NSString).appendingPathComponent(String(format: "test%08x", arc4random()))
+        try? FileManager.default.createDirectory(atPath: cachePath, withIntermediateDirectories: false, attributes: nil)
+        
+        cache = {
+            return PersistentAutoPurgingImageCache(persistencePath: self.cachePath)
+        }()
+    }
+    
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: cachePath)
+        super.tearDown()
+    }
+    
+    func testThatItCanAddImageToCacheWithIdentifier() {
+        let image = self.image(forResource: "unicorn", withExtension: "png")
+        let identifier = "unicorn"
+        
+        let expectation1 = expectation(description: "image cache should succeed")
+
+        cache.add(image, withIdentifier: identifier) {
+            expectation1.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        let expectedImagePath = (cachePath as NSString).appendingPathComponent(identifier)
+        
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expectedImagePath))
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: expectedImagePath)) else {
+            XCTFail("data should not bbe nil")
+            return
+        }
+        
+        #if os(iOS) || os(tvOS) || os(watchOS)
+            guard let cachedImage = UIImage(data: data, scale: image.scale) else {
+                XCTFail("Image should not be nil")
+                return
+            }
+        #elseif os(macOS)
+            guard let cachedImage = NSImage(data: data) else {
+                XCTFail("Image should not be nil")
+                return
+            }
+        #endif
+        
+        XCTAssertEqual(cachedImage.size, image.size)
+    }
+    
+    func testThatAddedImagesHasCorrectExpirationDate() {
+        let image = self.image(forResource: "unicorn", withExtension: "png")
+        let identifier = "unicorn"
+        
+        let timeToLive: TimeInterval = 60
+
+        let expectation1 = expectation(description: "image cache should succeed")
+        
+        cache.add(image, withIdentifier: identifier, andTimeToLive: timeToLive) {
+            expectation1.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        let expectedExpiration = Date().addingTimeInterval(timeToLive).timeIntervalSince1970
+        let path = (cachePath as NSString).appendingPathComponent(identifier)
+        
+        var expiration: TimeInterval = 0
+        getxattr(path, "org.alamofire.persistentautopurgingimagecache-expiration", &expiration, MemoryLayout<TimeInterval>.size, 0, 0)
+        
+        XCTAssertEqualWithAccuracy(expectedExpiration, expiration, accuracy: 3)
+    }
+    
+    func testThatAddedImagesHasCorrectRemainingTimeToLive() {
+        let image = self.image(forResource: "unicorn", withExtension: "png")
+        let identifier = "unicorn"
+        
+        let timeToLive: TimeInterval = 60
+        
+        let expectation1 = expectation(description: "image cache should succeed")
+        
+        cache.add(image, withIdentifier: identifier, andTimeToLive: timeToLive) {
+            expectation1.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        guard let remainingLife = cache.remainingLifeForImage(withIdentifier: identifier) else {
+            XCTFail("Remaining life should not be nil")
+            return
+        }
+        
+        XCTAssertEqualWithAccuracy(timeToLive, remainingLife, accuracy: 3)
+    }
+    
+    func testThatInexistingFilesReturnsNilTimeToLive() {
+        let remainingLife = cache.remainingLifeForImage(withIdentifier: "N/A")
+        XCTAssertNil(remainingLife)
+    }
+}


### PR DESCRIPTION
This pull request add a new ImageCache implementation called PersistentAutoPurgingImageCache which is a subclass of AutoPurgingImageCache. On add the image is asynchronously saved on disk, and on fetch if the image is not available in memory, it will be fetched from disk (if present). A time to live is associated with the image, and a cleanup logic will keep tidy the chosen cache folder.

The feature is fully unit tested.

This PR was made to address the issue https://github.com/Alamofire/AlamofireImage/issues/5

For testability purposes a version of the add method with a completion block was added.