### PR TITLE
Issues/277 support uiimage self scaling by dpi property

### DIFF
--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -77,7 +77,6 @@ extension DataRequest {
     ///
     /// - returns: An image response serializer.
     public class func imageResponseSerializer(
-        imageScale: CGFloat = DataRequest.imageScale,
         inflateResponseImage: Bool = true)
         -> DataResponseSerializer<Image>
     {
@@ -89,7 +88,7 @@ extension DataRequest {
             do {
                 try DataRequest.validateContentType(for: request, response: response)
 
-                let image = try DataRequest.image(from: data, withImageScale: imageScale)
+                let image = try DataRequest.image(from: data)
                 if inflateResponseImage { image.af_inflate() }
 
                 return .success(image)
@@ -121,8 +120,7 @@ extension DataRequest {
     ///
     /// - returns: The request.
     @discardableResult
-    public func responseImage(
-        imageScale: CGFloat = DataRequest.imageScale,
+    public func responseImage(      
         inflateResponseImage: Bool = true,
         queue: DispatchQueue? = nil,
         completionHandler: @escaping (DataResponse<Image>) -> Void)
@@ -131,7 +129,6 @@ extension DataRequest {
         return response(
             queue: queue,
             responseSerializer: DataRequest.imageResponseSerializer(
-                imageScale: imageScale,
                 inflateResponseImage: inflateResponseImage
             ),
             completionHandler: completionHandler
@@ -180,14 +177,13 @@ extension DataRequest {
 
     private class func serializeImage(
         from data: Data,
-        imageScale: CGFloat = DataRequest.imageScale,
         inflateResponseImage: Bool = true)
         -> UIImage?
     {
         guard data.count > 0 else { return nil }
 
         do {
-            let image = try DataRequest.image(from: data, withImageScale: imageScale)
+            let image = try DataRequest.image(from: data)
             if inflateResponseImage { image.af_inflate() }
 
             return image
@@ -196,7 +192,8 @@ extension DataRequest {
         }
     }
 
-    private class func image(from data: Data, withImageScale imageScale: CGFloat) throws -> UIImage {
+    private class func image(from data: Data) throws -> UIImage {
+      let imageScale = UIImage.af_imageScale(from: data) ?? DataRequest.imageScale
         if let image = UIImage.af_threadSafeImage(with: data, scale: imageScale) {
             return image
         }

--- a/Source/UIImage+AlamofireImage.swift
+++ b/Source/UIImage+AlamofireImage.swift
@@ -26,6 +26,7 @@
 
 import CoreGraphics
 import Foundation
+import ImageIO
 import UIKit
 
 // MARK: Initialization
@@ -33,6 +34,25 @@ import UIKit
 private let lock = NSLock()
 
 extension UIImage {
+    
+    /// Extract DPIHeight property from CFImageSource and return scale depend on it
+    ///
+    /// - parameter data: The data object containing the image data.
+    ///
+    /// - returns: A scale property based on image data 'DPIHeight' property (if exist)
+    public static func af_imageScale(from data: Data) -> CGFloat? {
+        guard let imageSource = CGImageSourceCreateWithData(data as CFData, nil) else {
+            return nil
+        }
+        let cfDict = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil)
+        guard let dpiUnsafeValue = CFDictionaryGetValue(cfDict, unsafeBitCast(kCGImagePropertyDPIHeight, to: UnsafeRawPointer.self)) else {
+            return nil
+        }
+        let dpi = unsafeBitCast(dpiUnsafeValue, to: CFNumber.self)
+        let dpiNumber = (dpi as NSNumber).floatValue
+        return CGFloat(dpiNumber) / CGFloat(72.0)
+    }
+    
     /// Initializes and returns the image object with the specified data in a thread-safe manner.
     ///
     /// It has been reported that there are thread-safety issues when initializing large amounts of images

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -29,7 +29,7 @@ import XCTest
 
 class DataRequestTestCase: BaseTestCase {
     var acceptableImageContentTypes: Set<String>!
-
+    private let pointEqualAccuracy: CGFloat = 0.00001
     // MARK: - Setup and Teardown
     override func setUp() {
         super.setUp()
@@ -84,8 +84,9 @@ class DataRequestTestCase: BaseTestCase {
             #if os(iOS)
                 let screenScale = UIScreen.main.scale //Use screen scale cause taht image haven't DPI in metadata properties
                 let expectedSize = CGSize(width: CGFloat(100) / screenScale, height: CGFloat(100) / screenScale)
-                XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
-                XCTAssertEqual(image.scale, screenScale, "image scale does not match expected value")
+                XCTAssertEqualWithAccuracy(image.size.width, expectedSize.width, accuracy: pointEqualAccuracy, "image width does not match expected value")
+                XCTAssertEqualWithAccuracy(image.size.height, expectedSize.height, accuracy: pointEqualAccuracy, "image height does not match expected value")
+                XCTAssertEqualWithAccuracy(image.scale, screenScale, accuracy: pointEqualAccuracy, "image scale does not match expected value")
             #elseif os(macOS)
                 let expectedSize = CGSize(width: 100.0, height: 100.0)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
@@ -121,10 +122,10 @@ class DataRequestTestCase: BaseTestCase {
 
         if let image = response?.result.value {
             #if os(iOS)
-                let imageScale = testImageDPI / CGFloat(72.0)
-                let expectedSize = CGSize(width: CGFloat(239) / imageScale, height: CGFloat(178) / imageScale)
-                XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
-                XCTAssertEqual(image.scale, imageScale, "image scale does not match expected value")
+                let expectedSize = CGSize(width: CGFloat(239) / testImageScale, height: CGFloat(178) / testImageScale)
+                XCTAssertEqualWithAccuracy(image.size.width, expectedSize.width, accuracy: pointEqualAccuracy, "image width does not match expected value")
+                XCTAssertEqualWithAccuracy(image.size.height, expectedSize.height, accuracy: pointEqualAccuracy, "image height does not match expected value")
+                XCTAssertEqualWithAccuracy(image.scale, testImageScale, accuracy: pointEqualAccuracy, "image scale does not match expected value")
             #elseif os(macOS)
                 let expectedSize = CGSize(width: 239.0, height: 178.0)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
@@ -160,8 +161,9 @@ class DataRequestTestCase: BaseTestCase {
         if let image = response?.result.value {
             #if os(iOS)
                 let expectedSize = CGSize(width: CGFloat(180) / testImageScale, height: CGFloat(260) / testImageScale)
-                XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
-                XCTAssertEqual(image.scale, testImageScale, "image scale does not match expected value")
+                XCTAssertEqualWithAccuracy(image.size.width, expectedSize.width, accuracy: pointEqualAccuracy, "image width does not match expected value")
+                XCTAssertEqualWithAccuracy(image.size.height, expectedSize.height, accuracy: pointEqualAccuracy, "image height does not match expected value")
+                XCTAssertEqualWithAccuracy(image.scale, testImageScale, accuracy: pointEqualAccuracy, "image scale does not match expected value")
             #elseif os(macOS)
                 let expectedSize = CGSize(width: 180.0, height: 260.0)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
@@ -198,9 +200,9 @@ class DataRequestTestCase: BaseTestCase {
         if let image = response?.result.value {
             let screenScale = UIScreen.main.scale //Use screen scale cause taht image haven't DPI in metadata properties
             let expectedSize = CGSize(width: CGFloat(100) / screenScale, height: CGFloat(100) / screenScale)
-
-            XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
-            XCTAssertEqual(image.scale, screenScale, "image scale does not match expected value")
+            XCTAssertEqualWithAccuracy(image.size.width, expectedSize.width, accuracy: pointEqualAccuracy, "image width does not match expected value")
+            XCTAssertEqualWithAccuracy(image.size.height, expectedSize.height, accuracy: pointEqualAccuracy, "image height does not match expected value")
+            XCTAssertEqualWithAccuracy(image.scale, screenScale, accuracy: pointEqualAccuracy, "image scale does not match expected value")
         } else {
             XCTFail("result image should not be nil")
         }
@@ -231,9 +233,9 @@ class DataRequestTestCase: BaseTestCase {
 
         if let image = response?.result.value {
             let expectedSize = CGSize(width: CGFloat(239) / testImageScale, height: CGFloat(178) / testImageScale)
-
-            XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
-            XCTAssertEqual(image.scale, testImageScale, "image scale does not match expected value")
+            XCTAssertEqualWithAccuracy(image.size.width, expectedSize.width, accuracy: pointEqualAccuracy, "image width does not match expected value")
+            XCTAssertEqualWithAccuracy(image.size.height, expectedSize.height, accuracy: pointEqualAccuracy, "image height does not match expected value")
+            XCTAssertEqualWithAccuracy(image.scale, testImageScale, accuracy: pointEqualAccuracy, "image scale does not match expected value")
         } else {
             XCTFail("result image should not be nil")
         }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -31,7 +31,6 @@ class DataRequestTestCase: BaseTestCase {
     var acceptableImageContentTypes: Set<String>!
 
     // MARK: - Setup and Teardown
-
     override func setUp() {
         super.setUp()
         acceptableImageContentTypes = DataRequest.acceptableImageContentTypes
@@ -64,7 +63,7 @@ class DataRequestTestCase: BaseTestCase {
         // Given
         let urlString = "https://httpbin.org/image/png"
         let expectation = self.expectation(description: "Request should return PNG response image")
-
+        
         var response: DataResponse<Image>?
 
         // When
@@ -83,7 +82,7 @@ class DataRequestTestCase: BaseTestCase {
 
         if let image = response?.result.value {
             #if os(iOS)
-                let screenScale = UIScreen.main.scale
+                let screenScale = UIScreen.main.scale //Use screen scale cause taht image haven't DPI in metadata properties
                 let expectedSize = CGSize(width: CGFloat(100) / screenScale, height: CGFloat(100) / screenScale)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
                 XCTAssertEqual(image.scale, screenScale, "image scale does not match expected value")
@@ -100,6 +99,9 @@ class DataRequestTestCase: BaseTestCase {
         // Given
         let urlString = "https://httpbin.org/image/jpeg"
         let expectation = self.expectation(description: "Request should return JPG response image")
+        
+        let testImageDPI: CGFloat = 71.12 //From jpeg file properties
+        let testImageScale = CGFloat(71.12) / CGFloat(72.0)
 
         var response: DataResponse<Image>?
 
@@ -119,10 +121,10 @@ class DataRequestTestCase: BaseTestCase {
 
         if let image = response?.result.value {
             #if os(iOS)
-                let screenScale = UIScreen.main.scale
-                let expectedSize = CGSize(width: CGFloat(239) / screenScale, height: CGFloat(178) / screenScale)
+                let imageScale = testImageDPI / CGFloat(72.0)
+                let expectedSize = CGSize(width: CGFloat(239) / imageScale, height: CGFloat(178) / imageScale)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
-                XCTAssertEqual(image.scale, screenScale, "image scale does not match expected value")
+                XCTAssertEqual(image.scale, imageScale, "image scale does not match expected value")
             #elseif os(macOS)
                 let expectedSize = CGSize(width: 239.0, height: 178.0)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
@@ -136,6 +138,8 @@ class DataRequestTestCase: BaseTestCase {
         // Given
         let url = self.url(forResource: "apple", withExtension: "jpg")
         let expectation = self.expectation(description: "Request should return JPG response image")
+        let testImageDPI: CGFloat = 72 //From jpeg file properties
+        let testImageScale = testImageDPI / CGFloat(72.0)
 
         var response: DataResponse<Image>?
 
@@ -155,10 +159,9 @@ class DataRequestTestCase: BaseTestCase {
 
         if let image = response?.result.value {
             #if os(iOS)
-                let screenScale = UIScreen.main.scale
-                let expectedSize = CGSize(width: CGFloat(180) / screenScale, height: CGFloat(260) / screenScale)
+                let expectedSize = CGSize(width: CGFloat(180) / testImageScale, height: CGFloat(260) / testImageScale)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
-                XCTAssertEqual(image.scale, screenScale, "image scale does not match expected value")
+                XCTAssertEqual(image.scale, testImageScale, "image scale does not match expected value")
             #elseif os(macOS)
                 let expectedSize = CGSize(width: 180.0, height: 260.0)
                 XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
@@ -176,7 +179,6 @@ class DataRequestTestCase: BaseTestCase {
         // Given
         let urlString = "https://httpbin.org/image/png"
         let expectation = self.expectation(description: "Request should return PNG response image")
-
         var response: DataResponse<Image>?
 
         // When
@@ -194,7 +196,7 @@ class DataRequestTestCase: BaseTestCase {
         XCTAssertTrue(response?.result.isSuccess ?? false, "result should be success")
 
         if let image = response?.result.value {
-            let screenScale = UIScreen.main.scale
+            let screenScale = UIScreen.main.scale //Use screen scale cause taht image haven't DPI in metadata properties
             let expectedSize = CGSize(width: CGFloat(100) / screenScale, height: CGFloat(100) / screenScale)
 
             XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
@@ -208,7 +210,9 @@ class DataRequestTestCase: BaseTestCase {
         // Given
         let urlString = "https://httpbin.org/image/jpeg"
         let expectation = self.expectation(description: "Request should return JPG response image")
-
+        let testImageDPI: CGFloat = 71.12 //From jpeg file properties
+        let testImageScale = testImageDPI / CGFloat(72.0)
+        
         var response: DataResponse<Image>?
 
         // When
@@ -226,11 +230,10 @@ class DataRequestTestCase: BaseTestCase {
         XCTAssertTrue(response?.result.isSuccess ?? false, "result should be success")
 
         if let image = response?.result.value {
-            let screenScale = UIScreen.main.scale
-            let expectedSize = CGSize(width: CGFloat(239) / screenScale, height: CGFloat(178) / screenScale)
+            let expectedSize = CGSize(width: CGFloat(239) / testImageScale, height: CGFloat(178) / testImageScale)
 
             XCTAssertEqual(image.size, expectedSize, "image size does not match expected value")
-            XCTAssertEqual(image.scale, screenScale, "image scale does not match expected value")
+            XCTAssertEqual(image.scale, testImageScale, "image scale does not match expected value")
         } else {
             XCTFail("result image should not be nil")
         }


### PR DESCRIPTION
Image DPI extracts from CFImageSource properties and imageScale implements based on DPIHeight. If that property hasn't setted, default UIScreen.main.scale using (like before)