### PR TITLE
Fix for issue #293

### DIFF
--- a/Source/UIImageView+AlamofireImage.swift
+++ b/Source/UIImageView+AlamofireImage.swift
@@ -285,13 +285,11 @@ extension UIImageView {
             let response = DataResponse<UIImage>(request: request, response: nil, data: nil, result: .success(image))
 
             if runImageTransitionIfCached {
-                let tinyDelay = DispatchTime.now() + Double(Int64(0.001 * Float(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
-
-                // Need to let the runloop cycle for the placeholder image to take affect
-                DispatchQueue.main.asyncAfter(deadline: tinyDelay) {
-                    self.run(imageTransition, with: image)
-                    completion?(response)
-                }
+                // Set the placeholder
+                if let placeholderImage = placeholderImage { self.image = placeholderImage }
+              
+                self.run(imageTransition, with: image)
+                completion?(response)
             } else {
                 self.image = image
                 completion?(response)


### PR DESCRIPTION
Image transition for cached image hit does not need to be called as a delayed async GCD block. It just needs to set the placeholder image before running the image transition. If the delayed block is used, then if the image request is cancelled, the block is not cancelled. And a subsequent new image request that has no image transition and also hits the cache will be possibly overwritten with the delayed block, causing the wrong image to be displayed. This issue is resolved with the code change.

### Issue Link :link:
#293 

### Goals :soccer:
Resolves image display error when af_cancelImageRequest is called and a new image url is set. The previous cached image is erroneously displayed instead of the newly referenced image.

### Implementation Details :construction:
I wanted to resolve the issue with the least amount of change to the code. Following the code flow/logic, it seems the only reason the async block was used was to make sure the placeholder image is set before the image transition occurs. Therefore, the async block can be replaced with just inline code that sets the placeholder image and then executes the image transition and completion routine right away.

### Testing Details :mag:
I tested this change in my app that relies on AlamofireImage, and it resolved the error.