### PR TITLE
Update Gravatar.swift

### DIFF
--- a/Example/Gravatar.swift
+++ b/Example/Gravatar.swift
@@ -105,7 +105,9 @@ public struct Gravatar {
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
 
         var queryItems = [defaultImage.queryItem, rating.queryItem]
-        queryItems.append(URLQueryItem(name: "f", value: forceDefault ? "y" : "n"))
+        if forceDefault {
+            queryItems.append(URLQueryItem(name: "f", value: "y"))
+        }
         queryItems.append(URLQueryItem(name: "s", value: String(format: "%.0f",size * scale)))
 
         components.queryItems = queryItems


### PR DESCRIPTION
In the Gravatar example, once sending the **f** (force) Query String parameter the gravatar always force the the default image no matter the value of the parameter. 

### Goals :soccer:
- Fix Gravatar example

### Implementation Details :construction:
- Add or not the parameter instead of defining a different value that in fact is not currently working

### Testing Details :mag:
As a simple test I've tried the following 4 URLs and only the last one returns my gravatar, the other 3 returns the default image: 

 - https://s.gravatar.com/avatar/3fe96e96013875d792fdf56fdc9da50d?d=mm&r=pg&f=n&s=640
 - https://s.gravatar.com/avatar/3fe96e96013875d792fdf56fdc9da50d?d=mm&r=pg&f=y&s=640
 - https://s.gravatar.com/avatar/3fe96e96013875d792fdf56fdc9da50d?d=mm&r=pg&f=&s=640
 - https://s.gravatar.com/avatar/3fe96e96013875d792fdf56fdc9da50d?d=mm&r=pg&s=640
