### PR TITLE
Specify Swift version in podspec

### DIFF
--- a/AlamofireImage.podspec
+++ b/AlamofireImage.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
 
   s.source = { :git => 'https://github.com/Alamofire/AlamofireImage.git', :tag => s.version }
   s.source_files = 'Source/*.swift'
+  s.swift_version = '3.2'
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'


### PR DESCRIPTION
This helps when using AlamofireImage on a Swift 4 project in Xcode 10.

### Goals :soccer:
When using AlamofireImage from CocoaPods in Xcode 10, the Swift version will be set properly and building succeeds.

### Implementation Details :construction:
This just adds the `swift_version` attribute to the root-level pod spec. There’s also a `.swift_version` file, but CocoaPods doesn’t look at that when creating its Xcode project (perhaps this could be an enhancement to CocoaPods).

### Testing Details :mag:
To test this, create a new project in Xcode 10 and add AlamofireImage using CocoaPods. The release version will fail, but this version will succeed.