### PR TITLE
Issue 323: Caching fails with custom SessionManager

### DIFF
--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -269,6 +269,7 @@ open class ImageDownloader {
         -> RequestReceipt?
     {
         var request: DataRequest!
+        let originalURLRequest = urlRequest.urlRequest
 
         synchronizationQueue.sync {
             // 1) Append the filter and completion handler to a pre-existing request if it already exists
@@ -356,7 +357,7 @@ open class ImageDownloader {
                                 filteredImage = image
                             }
 
-                            strongSelf.imageCache?.add(filteredImage, for: request, withIdentifier: filter?.identifier)
+                            strongSelf.imageCache?.add(filteredImage, for: (originalURLRequest ?? request), withIdentifier: filter?.identifier)
 
                             DispatchQueue.main.async {
                                 let response = DataResponse<Image>(


### PR DESCRIPTION
Issue 323: Caching fails with custom SessionManager with a request adapter modifying the url

Fix by caching the image keyed by the original request instead of the adapted one.

### Issue Link :link:
[Caching fails with custom SessionManager with a request adapter modifying the url #323](https://github.com/Alamofire/AlamofireImage/issues/323)