### PR TITLE
Updated the Podspec to match 5.0.0-beta.2 tag of Alamofire

### DIFF
--- a/AlamofireImage.podspec
+++ b/AlamofireImage.podspec
@@ -11,10 +11,10 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/Alamofire/AlamofireImage.git', :tag => s.version }
   s.source_files = 'Source/*.swift'
 
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '9.0'
-  s.watchos.deployment_target = '2.0'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '10.0'
+  s.watchos.deployment_target = '3.0'
 
-  s.dependency 'Alamofire', '~> 4.8'
+  s.dependency 'Alamofire', '5.0.0-beta.2'
 end


### PR DESCRIPTION
### Issue Link :link:
https://github.com/Alamofire/AlamofireImage/issues/336 You can't add AlamofireImage to your Project with CocoaPods when using Alamofire 5.0.0-beta.2

### Goals :soccer:
Make AlamofireImage `alamofire5` branch work with Alamofire 5.0.0-beta.2

### Implementation Details :construction:
Fixed dependency and deployment_target to match Alamofire 5

### Example of usage in Podfile 🥇 
```
platform :ios, '10.0'
use_frameworks!

target 'TargetUsingAlamofire' do
    pod 'Alamofire', '~> 5.0.0-beta.2'
    pod 'AlamofireImage', :git => 'https://github.com/andiradulescu/AlamofireImage.git', :branch => 'alamofire5'
end
```