### PR TITLE
Fix build using Xcode 9.4.1.

### DIFF
--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -458,8 +458,14 @@ open class ImageDownloader {
         synchronizationQueue.sync {
             let urlID = ImageDownloader.urlIdentifier(for: requestReceipt.request.request!)
             guard let responseHandler = self.responseHandlers[urlID] else { return }
-
-            if let index = responseHandler.operations.firstIndex(where: { $0.receiptID == requestReceipt.receiptID }) {
+            
+            #if swift(>=4.2)
+            let index = responseHandler.operations.firstIndex { $0.receiptID == requestReceipt.receiptID }
+            #else
+            let index = responseHandler.operations.index { $0.receiptID == requestReceipt.receiptID }
+            #endif
+            
+            if let index = index {
                 let operation = responseHandler.operations.remove(at: index)
 
                 let response: DataResponse<Image> = {

--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -48,8 +48,12 @@ extension DataRequest {
         "image/x-ms-bmp",
         "image/x-win-bitmap"
     ]
-
+    
+    #if swift(>=5)
     static let streamImageInitialBytePattern = Data([255, 216]) // 0xffd8
+    #else
+    static let streamImageInitialBytePattern = Data(bytes: [255, 216]) // 0xffd8
+    #endif
 
     /// Adds the content types specified to the list of acceptable images content types for validation.
     ///


### PR DESCRIPTION
### Issue Link :link:
#349

### Goals :soccer:
This PR fixes build issues with Xcode 9.4.1 and makes some changes suggested by the Swift 5 compiler vary by Swift version. Compatibility mode is not backwards compatible.

### Implementation Details :construction:
Had to use `#if swift` rather than `#if compiler` since Xcode 9 is so old. :(