### PR TITLE
Project - Updating to Alamofire 5.0.0-beta.5

### DIFF
--- a/AlamofireImage.podspec
+++ b/AlamofireImage.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.0'
 
-  s.dependency 'Alamofire', '~> 5.0.0-beta.4'
+  s.dependency 'Alamofire', '~> 5.0.0-beta.5'
 end

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "5.0.0-beta.4"
+github "Alamofire/Alamofire" "5.0.0-beta.5"

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -135,7 +135,7 @@ open class ImageDownloader {
     open class func defaultURLSessionConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.default
 
-        configuration.httpHeaders = .default
+        configuration.headers = .default
         configuration.httpShouldSetCookies = true
         configuration.httpShouldUsePipelining = false
 


### PR DESCRIPTION
This PR bumps the AF5 dependency to 5.0.0-beta.5 and fixes a compiler error with the `headers` property refactor in beta 5.

### Goals :soccer:
To get AFI compiling against AF5b5.

### Implementation Details :construction:
N/A

### Testing Details :mag:
N/A
