### PR TITLE
Bugfix from 4.0.0.beta.2 to 4.0.0 in CFBundleShortVersionString

### DIFF
--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0.beta.2</string>
+	<string>4.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
remove the .beta.2 from CFBundleShortVersionString key in info.plist in order to be able distribute the app

This PR drops the pre-release version from the CFBundleShortVersionString in the Info.plist.

Goals ⚽️

To allow users to be able to submit Alamofire Image betas to the AppStore using submodules and Carthage.

Implementation Details 🚧

N/A

Testing Details 🔍

N/A