### PR TITLE
Add scale parameter to scale methods to allow setting the output image's scale.

### DIFF
--- a/Source/UIImage+AlamofireImage.swift
+++ b/Source/UIImage+AlamofireImage.swift
@@ -130,11 +130,14 @@ extension UIImage {
     ///
     /// - parameter size: The size to use when scaling the new image.
     ///
+    /// - parameter scale: The scale factor for the new image. If omitted or set to zero will use the default main screen
+    ///   scale (UIScreen.main.scale)
+    ///
     /// - returns: A new image object.
-    public func af_imageScaled(to size: CGSize) -> UIImage {
+    public func af_imageScaled(to size: CGSize, scale: CGFloat = 0.0) -> UIImage {
         assert(size.width > 0 && size.height > 0, "You cannot safely scale an image to a zero width or height")
 
-        UIGraphicsBeginImageContextWithOptions(size, af_isOpaque, 0.0)
+        UIGraphicsBeginImageContextWithOptions(size, af_isOpaque, scale)
         draw(in: CGRect(origin: .zero, size: size))
 
         let scaledImage = UIGraphicsGetImageFromCurrentImageContext() ?? self
@@ -153,8 +156,11 @@ extension UIImage {
     ///
     /// - parameter size: The size to use when scaling the new image.
     ///
+    /// - parameter scale: The scale factor for the new image. If omitted or set to zero will use the default main screen
+    ///   scale (UIScreen.main.scale)
+    ///
     /// - returns: A new image object.
-    public func af_imageAspectScaled(toFit size: CGSize) -> UIImage {
+    public func af_imageAspectScaled(toFit size: CGSize, scale: CGFloat = 0.0) -> UIImage {
         assert(size.width > 0 && size.height > 0, "You cannot safely scale an image to a zero width or height")
 
         let imageAspectRatio = self.size.width / self.size.height
@@ -171,7 +177,7 @@ extension UIImage {
         let scaledSize = CGSize(width: self.size.width * resizeFactor, height: self.size.height * resizeFactor)
         let origin = CGPoint(x: (size.width - scaledSize.width) / 2.0, y: (size.height - scaledSize.height) / 2.0)
 
-        UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+        UIGraphicsBeginImageContextWithOptions(size, false, scale)
         draw(in: CGRect(origin: origin, size: scaledSize))
 
         let scaledImage = UIGraphicsGetImageFromCurrentImageContext() ?? self
@@ -185,8 +191,11 @@ extension UIImage {
     ///
     /// - parameter size: The size to use when scaling the new image.
     ///
+    /// - parameter scale: The scale factor for the new image. If omitted or set to zero will use the default main screen
+    ///   scale (UIScreen.main.scale)
+    ///
     /// - returns: A new image object.
-    public func af_imageAspectScaled(toFill size: CGSize) -> UIImage {
+    public func af_imageAspectScaled(toFill size: CGSize, scale: CGFloat = 0.0) -> UIImage {
         assert(size.width > 0 && size.height > 0, "You cannot safely scale an image to a zero width or height")
 
         let imageAspectRatio = self.size.width / self.size.height
@@ -203,7 +212,7 @@ extension UIImage {
         let scaledSize = CGSize(width: self.size.width * resizeFactor, height: self.size.height * resizeFactor)
         let origin = CGPoint(x: (size.width - scaledSize.width) / 2.0, y: (size.height - scaledSize.height) / 2.0)
 
-        UIGraphicsBeginImageContextWithOptions(size, af_isOpaque, 0.0)
+        UIGraphicsBeginImageContextWithOptions(size, af_isOpaque, scale)
         draw(in: CGRect(origin: origin, size: scaledSize))
 
         let scaledImage = UIGraphicsGetImageFromCurrentImageContext() ?? self

--- a/Tests/UIImageTests.swift
+++ b/Tests/UIImageTests.swift
@@ -268,6 +268,46 @@ class UIImageTestCase: BaseTestCase {
         XCTAssertEqual(scaledRainbowImage.scale, CGFloat(scale), "image scale should be equal to screen scale")
         XCTAssertEqual(scaledUnicornImage.scale, CGFloat(scale), "image scale should be equal to screen scale")
     }
+    
+    func testThatImageIsScaledWithProperScale() {
+        // Given
+        let size = squareSize
+        let scale = UIScreen.main.scale
+        
+        // When
+        let scaledToSizeAppleImageScaleDefault = appleImage.af_imageScaled(to: size)
+        let scaledToFitAppleImageScaleDefault = appleImage.af_imageAspectScaled(toFit: size)
+        let scaledToFillAppleImageScaleDefault = appleImage.af_imageAspectScaled(toFill: size)
+        let scaledToSizeAppleImageScale0 = appleImage.af_imageScaled(to: size, scale: 0.0)
+        let scaledToFitAppleImageScale0 = appleImage.af_imageAspectScaled(toFit: size, scale: 0.0)
+        let scaledToFillAppleImageScale0 = appleImage.af_imageAspectScaled(toFill: size, scale: 0.0)
+        let scaledToSizeAppleImageScale1 = appleImage.af_imageScaled(to: size, scale: 1.0)
+        let scaledToFitAppleImageScale1 = appleImage.af_imageAspectScaled(toFit: size, scale: 1.0)
+        let scaledToFillAppleImageScale1 = appleImage.af_imageAspectScaled(toFill: size, scale: 1.0)
+        let scaledToSizeAppleImageScale2 = appleImage.af_imageScaled(to: size, scale: 2.0)
+        let scaledToFitAppleImageScale2 = appleImage.af_imageAspectScaled(toFit: size, scale: 2.0)
+        let scaledToFillAppleImageScale2 = appleImage.af_imageAspectScaled(toFill: size, scale: 2.0)
+        let scaledToSizeAppleImageScale3 = appleImage.af_imageScaled(to: size, scale: 3.0)
+        let scaledToFitAppleImageScale3 = appleImage.af_imageAspectScaled(toFit: size, scale: 3.0)
+        let scaledToFillAppleImageScale3 = appleImage.af_imageAspectScaled(toFill: size, scale: 3.0)
+        
+        // Then
+        XCTAssertEqual(scaledToSizeAppleImageScaleDefault.scale, scale, "image scale should be equal to \(scale)")
+        XCTAssertEqual(scaledToFitAppleImageScaleDefault.scale, scale, "image scale should be equal to \(scale)")
+        XCTAssertEqual(scaledToFillAppleImageScaleDefault.scale, scale, "image scale should be equal to \(scale)")
+        XCTAssertEqual(scaledToSizeAppleImageScale0.scale, scale, "image scale should be equal to \(scale)")
+        XCTAssertEqual(scaledToFitAppleImageScale0.scale, scale, "image scale should be equal to \(scale)")
+        XCTAssertEqual(scaledToFillAppleImageScale0.scale, scale, "image scale should be equal to \(scale)")
+        XCTAssertEqual(scaledToSizeAppleImageScale1.scale, 1.0, "image scale should be equal to \(scale)")
+        XCTAssertEqual(scaledToFitAppleImageScale1.scale, 1.0, "image scale should be equal to 1.0")
+        XCTAssertEqual(scaledToFillAppleImageScale1.scale, 1.0, "image scale should be equal to 1.0")
+        XCTAssertEqual(scaledToSizeAppleImageScale2.scale, 2.0, "image scale should be equal to \(scale)")
+        XCTAssertEqual(scaledToFitAppleImageScale2.scale, 2.0, "image scale should be equal to 2.0")
+        XCTAssertEqual(scaledToFillAppleImageScale2.scale, 2.0, "image scale should be equal to 2.0")
+        XCTAssertEqual(scaledToSizeAppleImageScale3.scale, 3.0, "image scale should be equal to \(scale)")
+        XCTAssertEqual(scaledToFitAppleImageScale3.scale, 3.0, "image scale should be equal to 3.0")
+        XCTAssertEqual(scaledToFillAppleImageScale3.scale, 3.0, "image scale should be equal to 3.0")
+    }
 
     // MARK: - Rounded Corners
 


### PR DESCRIPTION
### Goals :soccer:
At some point I needed a way of cropping an image and setting its size in pixels. I couldn't use af_imageAspectScaled for that because internally it would use the device's main screen scale factor. So, for example, if i scaled an image to the size CGSize(width: 320, height: 320), on an iPhone 6 the resulting image would have the dimensions 640x640 (in pixels) and in an iPhone 6+ the dimenstions would be 960x960.

My goal on this pull request is to allow explicitly setting the scale when scaling images.

### Implementation Details :construction:
Modified the methods af_imageScaled(to size:), af_imageAspectScaled(toFill size:) and af_imageAspectScaled(toFit size:) to receive an additional parameter scale: CGFloat, which defaults to 0.0 (which is the defaul value set on UIGraphicsBeginImageContextWithOptions()).

### Testing Details :mag:
I've added the test UIImageTestCase.testThatImageIsScaledWithProperScale.
