### PR TITLE
added support for Project Catalyst, running on macOS

### DIFF
--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -152,11 +152,15 @@ open class ImageDownloader {
     ///
     /// - returns: The default `URLCache` instance.
     open class func defaultURLCache() -> URLCache {
+        #if !targetEnvironment(UIKitForMac)
         return URLCache(
             memoryCapacity: 20 * 1024 * 1024, // 20 MB
             diskCapacity: 150 * 1024 * 1024,  // 150 MB
             diskPath: "org.alamofire.imagedownloader"
         )
+        #else
+        return URLCache()
+        #endif
     }
 
     /// Initializes the `ImageDownloader` instance with the given configuration, download prioritization, maximum active

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -152,17 +152,21 @@ open class ImageDownloader {
     ///
     /// - returns: The default `URLCache` instance.
     open class func defaultURLCache() -> URLCache {
+        let memoryCapacity = 20 * 1024 * 1024
+        let diskCapacity = 150 * 1024 * 1024
+        let storageName = "org.alamofire.imagedownloader"
+        
         if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
             return URLCache(
-                memoryCapacity: 20 * 1024 * 1024, // 20 MB
-                diskCapacity: 150 * 1024 * 1024,  // 150 MB
-                directory: URL(string: "org.alamofire.imagedownloader")
+                memoryCapacity: memoryCapacity, // 20 MB
+                diskCapacity: diskCapacity,  // 150 MB
+                directory: URL(string: storageName)
             )
         } else {
             return URLCache(
-                memoryCapacity: 20 * 1024 * 1024, // 20 MB,
-                diskCapacity: 150 * 1024 * 1024,  // 150 MB,
-                diskPath: "org.alamofire.imagedownloader"
+                memoryCapacity: memoryCapacity, // 20 MB,
+                diskCapacity: diskCapacity,  // 150 MB,
+                diskPath: storageName
             )
         }
     }

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -152,18 +152,19 @@ open class ImageDownloader {
     ///
     /// - returns: The default `URLCache` instance.
     open class func defaultURLCache() -> URLCache {
-        #if !targetEnvironment(UIKitForMac)
-        return URLCache(
-            memoryCapacity: 20 * 1024 * 1024, // 20 MB
-            diskCapacity: 150 * 1024 * 1024,  // 150 MB
-            diskPath: "org.alamofire.imagedownloader"
-        )
-        #else
-        let urlCache = URLCache()
-        urlCache.memoryCapacity = 20 * 1024 * 1024 // 20 MB
-        urlCache.diskCapacity = 150 * 1024 * 1024  // 150 MB
-        return urlCache
-        #endif
+        if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+            return URLCache(
+                memoryCapacity: 20 * 1024 * 1024, // 20 MB
+                diskCapacity: 150 * 1024 * 1024,  // 150 MB
+                directory: URL(string: "org.alamofire.imagedownloader")
+            )
+        } else {
+            return URLCache(
+                memoryCapacity: 20 * 1024 * 1024, // 20 MB,
+                diskCapacity: 150 * 1024 * 1024,  // 150 MB,
+                diskPath: "org.alamofire.imagedownloader"
+            )
+        }
     }
 
     /// Initializes the `ImageDownloader` instance with the given configuration, download prioritization, maximum active

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -159,7 +159,10 @@ open class ImageDownloader {
             diskPath: "org.alamofire.imagedownloader"
         )
         #else
-        return URLCache()
+        let urlCache = URLCache()
+        urlCache.memoryCapacity = 20 * 1024 * 1024 // 20 MB
+        urlCache.diskCapacity = 150 * 1024 * 1024  // 150 MB
+        return urlCache
         #endif
     }
 

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -156,19 +156,17 @@ open class ImageDownloader {
         let diskCapacity = 150 * 1024 * 1024
         let storageName = "org.alamofire.imagedownloader"
         
-        if #available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-            return URLCache(
-                memoryCapacity: memoryCapacity, // 20 MB
-                diskCapacity: diskCapacity,  // 150 MB
-                directory: URL(string: storageName)
-            )
-        } else {
-            return URLCache(
-                memoryCapacity: memoryCapacity, // 20 MB,
-                diskCapacity: diskCapacity,  // 150 MB,
-                diskPath: storageName
-            )
-        }
+        #if targetEnvironment(macCatalyst)
+        return URLCache(
+            memoryCapacity: memoryCapacity,
+            diskCapacity: diskCapacity,
+            directory: URL(string: storageName)
+        )
+        #else
+        return URLCache(memoryCapacity: memoryCapacity,
+                        diskCapacity: diskCapacity,
+                        diskPath: storageName)
+        #endif
     }
 
     /// Initializes the `ImageDownloader` instance with the given configuration, download prioritization, maximum active

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -154,18 +154,25 @@ open class ImageDownloader {
     open class func defaultURLCache() -> URLCache {
         let memoryCapacity = 20 * 1024 * 1024
         let diskCapacity = 150 * 1024 * 1024
-        let storageName = "org.alamofire.imagedownloader"
+        let cacheDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+        let imageDownloaderPath = "org.alamofire.imagedownloader"
         
         #if targetEnvironment(macCatalyst)
         return URLCache(
             memoryCapacity: memoryCapacity,
             diskCapacity: diskCapacity,
-            directory: URL(string: storageName)
+            directory: cacheDirectory?.appendingPathComponent(imageDownloaderPath)
         )
+        #else
+        #if os(macOS)
+        return URLCache(memoryCapacity: memoryCapacity,
+                        diskCapacity: diskCapacity,
+                        diskPath: cacheDirectory?.appendingPathComponent(imageDownloaderPath).absoluteString)
         #else
         return URLCache(memoryCapacity: memoryCapacity,
                         diskCapacity: diskCapacity,
-                        diskPath: storageName)
+                        diskPath: imageDownloaderPath)
+        #endif
         #endif
     }
 


### PR DESCRIPTION

### Goals :soccer:
Bring support for macOS (project catalyst)
iPad apps can run on macOS Catalina, this PR bring support to that.

### Implementation Details :construction:
simply implement targetEnvironment around default cache, so it works with URLCache constructor provided on macOS / UIKit

### Testing Details :mag:
No test added