### PR TITLE
link to docs at top was out of date

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ AlamofireImage is an image component library for Alamofire.
 - [x] Authentication with URLCredential
 - [x] UIImageView Async Remote Downloads with Placeholders
 - [x] UIImageView Filters and Transitions
-- [x] Comprehensive Test Coverage
-- [x] [Complete Documentation](http://cocoadocs.org/docsets/AlamofireImage)
+- [x] Comprehensive Test Coverage 
+- [x] [Complete Documentation](https://alamofire.github.io/AlamofireImage/)
 
 ## Requirements
 


### PR DESCRIPTION
 the Cocoadocs documentation is out of date (http://cocoadocs.org/docsets/AlamofireImage) replaced link w/ the github hosted docs.

### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
