### PR TITLE
Fix image download request should be really cancelled

### DIFF
--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -476,7 +476,7 @@ open class ImageDownloader {
                 DispatchQueue.main.async { operation.completion?(response) }
             }
 
-            if responseHandler.operations.isEmpty && requestReceipt.request.task?.state == .suspended {
+            if responseHandler.operations.isEmpty {
                 requestReceipt.request.cancel()
                 self.responseHandlers.removeValue(forKey: urlID)
             }

--- a/Tests/ImageDownloaderTests.swift
+++ b/Tests/ImageDownloaderTests.swift
@@ -488,7 +488,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         let downloader = ImageDownloader()
         let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
 
-        let expectation = self.expectation(description: "download request should succeed")
+        let expectation = self.expectation(description: "download request should cancel")
 
         var response: DataResponse<Image>?
 


### PR DESCRIPTION

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
When I cancel task with image download receipt, I found the network is still downloaded the data. 
So once the task had been canceled, the network shouldn't download the image data anymore.

If each image is not cancelled correctly, it will cause the network downloaded the data that is related to users, If the image data is so large, that will cause a  memory pressure.
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
Even if the request is currently executing , it should be cancelled!
   
<!-- Highlight any new functionality. -->

