### PR TITLE
Update for Alamofire 5 RC Changes

### DIFF
--- a/AlamofireImage.podspec
+++ b/AlamofireImage.podspec
@@ -11,12 +11,11 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/Alamofire/AlamofireImage.git', :tag => s.version }
   s.source_files = 'Source/*.swift'
 
+  s.swift_versions = ['5.0', '5.1']
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '3.0'
 
-  s.swift_version = '5.0'
-
-  s.dependency 'Alamofire', '~> 5.0.0-beta.7'
+  s.dependency 'Alamofire', '~> 5.0.0-rc.1'
 end

--- a/AlamofireImage.podspec
+++ b/AlamofireImage.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '3.0'
 
-  s.dependency 'Alamofire', '~> 5.0.0-rc.1'
+  s.dependency 'Alamofire', '~> 5.0.0-rc.2'
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" ~> 5.0.0-beta.6
+github "Alamofire/Alamofire" ~> 5.0.0-rc.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" ~> 5.0.0-rc.1
+github "Alamofire/Alamofire" ~> 5.0.0-rc.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "5.0.0-rc.1"
+github "Alamofire/Alamofire" "5.0.0-rc.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "5.0.0-beta.7"
+github "Alamofire/Alamofire" "5.0.0-rc.1"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Alamofire",
+        "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
+        "state": {
+          "branch": null,
+          "revision": "82cc60d703dbced153baa04e26c6296ba9690a2d",
+          "version": "5.0.0-rc.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
         "state": {
           "branch": null,
-          "revision": "82cc60d703dbced153baa04e26c6296ba9690a2d",
-          "version": "5.0.0-rc.1"
+          "revision": "c1d14588e5558a3669fd03510d135d88c5109069",
+          "version": "5.0.0-rc.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/Alamofire/Alamofire.git",
-            from: Version(5, 0, 0, prereleaseIdentifiers: ["beta.7"])
+            from: Version(5, 0, 0, prereleaseIdentifiers: ["rc.1"])
         )
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/Alamofire/Alamofire.git",
-            from: Version(5, 0, 0, prereleaseIdentifiers: ["rc.1"])
+            from: "5.0.0-rc.2"
         )
     ],
     targets: [

--- a/Source/AFIError.swift
+++ b/Source/AFIError.swift
@@ -22,6 +22,7 @@
 //  THE SOFTWARE.
 //
 
+import Alamofire
 import Foundation
 
 /// `AFIError` is the error type returned by AlamofireImage.
@@ -31,6 +32,7 @@ import Foundation
 public enum AFIError: Error {
     case requestCancelled
     case imageSerializationFailed
+    case alamofireError(AFError)
 }
 
 // MARK: - Error Booleans
@@ -47,6 +49,11 @@ extension AFIError {
         if case .imageSerializationFailed = self { return true }
         return false
     }
+    
+    public var isAlamofireError: Bool {
+        if case .alamofireError = self { return true }
+        return false
+    }
 }
 
 // MARK: - Error Descriptions
@@ -58,6 +65,8 @@ extension AFIError: LocalizedError {
             return "The request was explicitly cancelled."
         case .imageSerializationFailed:
             return "Response data could not be serialized into an image."
+        case let .alamofireError(error):
+            return "Request failed due to an underlying Alamofire error: \(error.localizedDescription)"
         }
     }
 }

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -31,6 +31,9 @@ import UIKit
 import Cocoa
 #endif
 
+/// Alias for `DataResponse<T, AFIError>`.
+public typealias AFIDataResponse<T> = DataResponse<T, AFIError>
+
 /// The `RequestReceipt` is an object vended by the `ImageDownloader` when starting a download request. It can be used
 /// to cancel active requests running on the `ImageDownloader` session. As a general rule, image download requests
 /// should be cancelled using the `RequestReceipt` instead of calling `cancel` directly on the `request` itself. The
@@ -58,7 +61,7 @@ open class RequestReceipt {
 /// handlers for a single request.
 open class ImageDownloader {
     /// The completion handler closure used when an image download completes.
-    public typealias CompletionHandler = (DataResponse<Image>) -> Void
+    public typealias CompletionHandler = (AFIDataResponse<Image>) -> Void
 
     /// The progress handler closure called periodically during an image download.
     public typealias ProgressHandler = DataRequest.ProgressHandler
@@ -284,7 +287,7 @@ open class ImageDownloader {
                 case .useProtocolCachePolicy, .returnCacheDataElseLoad, .returnCacheDataDontLoad:
                     if let image = self.imageCache?.image(for: request, withIdentifier: filter?.identifier) {
                         DispatchQueue.main.async {
-                            let response = DataResponse<Image>(
+                            let response = AFIDataResponse<Image>(
                                 request: urlRequest.urlRequest,
                                 response: nil,
                                 data: nil,
@@ -360,7 +363,7 @@ open class ImageDownloader {
                             }
 
                             DispatchQueue.main.async {
-                                let response = DataResponse<Image>(
+                                let response = AFIDataResponse<Image>(
                                     request: response.request,
                                     response: response.response,
                                     data: response.data,
@@ -374,7 +377,7 @@ open class ImageDownloader {
                         }
                     case .failure:
                         for (_, _, completion) in responseHandler.operations {
-                            DispatchQueue.main.async { completion?(response) }
+                            DispatchQueue.main.async { completion?(response.mapError { AFIError.alamofireError($0) }) }
                         }
                     }
                 }
@@ -460,7 +463,7 @@ open class ImageDownloader {
             if let index = index {
                 let operation = responseHandler.operations.remove(at: index)
 
-                let response: DataResponse<Image> = {
+                let response: AFIDataResponse<Image> = {
                     let urlRequest = requestReceipt.request.request
                     let error = AFIError.requestCancelled
 

--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -34,6 +34,9 @@ import Cocoa
 /// Alias for `DataResponse<T, AFIError>`.
 public typealias AFIDataResponse<T> = DataResponse<T, AFIError>
 
+/// Alias for `Result<T, AFIError>`.
+public typealias AFIResult<T> = Result<T, AFIError>
+
 /// The `RequestReceipt` is an object vended by the `ImageDownloader` when starting a download request. It can be used
 /// to cancel active requests running on the `ImageDownloader` session. As a general rule, image download requests
 /// should be cancelled using the `RequestReceipt` instead of calling `cancel` directly on the `request` itself. The

--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -189,7 +189,7 @@ extension DataRequest {
         imageScale: CGFloat = DataRequest.imageScale,
         inflateResponseImage: Bool = true,
         queue: DispatchQueue = .main,
-        completionHandler: @escaping (DataResponse<Image>) -> Void)
+        completionHandler: @escaping (AFDataResponse<Image>) -> Void)
         -> Self
     {
         return response(
@@ -220,7 +220,7 @@ extension DataRequest {
     @discardableResult
     public func responseImage(
         queue: DispatchQueue = .main,
-        completionHandler: @escaping (DataResponse<Image>) -> Void)
+        completionHandler: @escaping (AFDataResponse<Image>) -> Void)
         -> Self
     {
         return response(

--- a/Source/UIButton+AlamofireImage.swift
+++ b/Source/UIButton+AlamofireImage.swift
@@ -133,7 +133,7 @@ extension UIButton {
         filter: ImageFilter? = nil,
         progress: ImageDownloader.ProgressHandler? = nil,
         progressQueue: DispatchQueue = DispatchQueue.main,
-        completion: ((DataResponse<UIImage>) -> Void)? = nil)
+        completion: ((AFIDataResponse<UIImage>) -> Void)? = nil)
     {
         af_setImage(
             for: state,
@@ -172,10 +172,10 @@ extension UIButton {
         filter: ImageFilter? = nil,
         progress: ImageDownloader.ProgressHandler? = nil,
         progressQueue: DispatchQueue = DispatchQueue.main,
-        completion: ((DataResponse<UIImage>) -> Void)? = nil)
+        completion: ((AFIDataResponse<UIImage>) -> Void)? = nil)
     {
         guard !isImageURLRequest(urlRequest, equalToActiveRequestURLForState: state) else {
-            let response = DataResponse<UIImage>(
+            let response = AFIDataResponse<UIImage>(
                 request: nil,
                 response: nil,
                 data: nil,
@@ -199,7 +199,7 @@ extension UIButton {
             let request = urlRequest.urlRequest,
             let image = imageCache?.image(for: request, withIdentifier: filter?.identifier)
         {
-            let response = DataResponse<UIImage>(
+            let response = AFIDataResponse<UIImage>(
                 request: urlRequest.urlRequest,
                 response: nil,
                 data: nil,
@@ -288,7 +288,7 @@ extension UIButton {
         filter: ImageFilter? = nil,
         progress: ImageDownloader.ProgressHandler? = nil,
         progressQueue: DispatchQueue = DispatchQueue.main,
-        completion: ((DataResponse<UIImage>) -> Void)? = nil)
+        completion: ((AFIDataResponse<UIImage>) -> Void)? = nil)
     {
         af_setBackgroundImage(
             for: state,
@@ -327,10 +327,10 @@ extension UIButton {
         filter: ImageFilter? = nil,
         progress: ImageDownloader.ProgressHandler? = nil,
         progressQueue: DispatchQueue = DispatchQueue.main,
-        completion: ((DataResponse<UIImage>) -> Void)? = nil)
+        completion: ((AFIDataResponse<UIImage>) -> Void)? = nil)
     {
         guard !isImageURLRequest(urlRequest, equalToActiveRequestURLForState: state) else {
-            let response = DataResponse<UIImage>(
+            let response = AFIDataResponse<UIImage>(
                 request: nil,
                 response: nil,
                 data: nil,
@@ -354,7 +354,7 @@ extension UIButton {
             let request = urlRequest.urlRequest,
             let image = imageCache?.image(for: request, withIdentifier: filter?.identifier)
         {
-            let response = DataResponse<UIImage>(
+            let response = AFIDataResponse<UIImage>(
                 request: urlRequest.urlRequest,
                 response: nil,
                 data: nil,

--- a/Source/UIImageView+AlamofireImage.swift
+++ b/Source/UIImageView+AlamofireImage.swift
@@ -210,7 +210,7 @@ extension UIImageView {
         progressQueue: DispatchQueue = DispatchQueue.main,
         imageTransition: ImageTransition = .noTransition,
         runImageTransitionIfCached: Bool = false,
-        completion: ((DataResponse<UIImage>) -> Void)? = nil)
+        completion: ((AFIDataResponse<UIImage>) -> Void)? = nil)
     {
         af_setImage(
             withURLRequest: urlRequest(with: url),
@@ -263,10 +263,10 @@ extension UIImageView {
         progressQueue: DispatchQueue = DispatchQueue.main,
         imageTransition: ImageTransition = .noTransition,
         runImageTransitionIfCached: Bool = false,
-        completion: ((DataResponse<UIImage>) -> Void)? = nil)
+        completion: ((AFIDataResponse<UIImage>) -> Void)? = nil)
     {
         guard !isURLRequestURLEqualToActiveRequestURL(urlRequest) else {
-            let response = DataResponse<UIImage>(
+            let response = AFIDataResponse<UIImage>(
                 request: nil,
                 response: nil,
                 data: nil,
@@ -290,7 +290,7 @@ extension UIImageView {
             let request = urlRequest.urlRequest,
             let image = imageCache?.image(for: request, withIdentifier: filter?.identifier)
         {
-            let response = DataResponse<UIImage>(
+            let response = AFIDataResponse<UIImage>(
                 request: request,
                 response: nil,
                 data: nil,

--- a/Tests/ImageDownloaderStressTests.swift
+++ b/Tests/ImageDownloaderStressTests.swift
@@ -49,7 +49,7 @@ class ImageDownloaderStressTestCase: BaseTestCase {
         expect.expectedFulfillmentCount = imageRequests.count
 
         var receipts: [RequestReceipt] = []
-        var responses: [DataResponse<Image>] = []
+        var responses: [AFIDataResponse<Image>] = []
 
         // When
         for imageRequest in imageRequests {
@@ -79,7 +79,7 @@ class ImageDownloaderStressTestCase: BaseTestCase {
         expect.expectedFulfillmentCount = imageRequests.count
 
         var receipts: [RequestReceipt] = []
-        var responses: [DataResponse<Image>] = []
+        var responses: [AFIDataResponse<Image>] = []
 
         // When
         for imageRequest in imageRequests {
@@ -117,7 +117,7 @@ class ImageDownloaderStressTestCase: BaseTestCase {
         expect.expectedFulfillmentCount = imageRequests.count
 
         var receipts: [RequestReceipt] = []
-        var responses: [DataResponse<Image>] = []
+        var responses: [AFIDataResponse<Image>] = []
 
         // When
         for imageRequest in imageRequests {
@@ -149,7 +149,7 @@ class ImageDownloaderStressTestCase: BaseTestCase {
         expect.expectedFulfillmentCount = imageRequests.count
 
         var receipts: [RequestReceipt] = []
-        var responses: [DataResponse<Image>] = []
+        var responses: [AFIDataResponse<Image>] = []
 
         // When
         for imageRequest in imageRequests {

--- a/Tests/ImageDownloaderTests.swift
+++ b/Tests/ImageDownloaderTests.swift
@@ -124,7 +124,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
-        var response: DataResponse<Image>?
+        var response: AFIDataResponse<Image>?
 
         // When
         downloader.download(urlRequest) { closureResponse in
@@ -151,8 +151,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         let expectation1 = expectation(description: "download 1 should succeed")
         let expectation2 = expectation(description: "download 2 should succeed")
 
-        var result1: AFResult<Image>?
-        var result2: AFResult<Image>?
+        var result1: Result<Image, AFIError>?
+        var result2: Result<Image, AFIError>?
 
         // When
         downloader.download(urlRequest1) { closureResponse in

--- a/Tests/ImageDownloaderTests.swift
+++ b/Tests/ImageDownloaderTests.swift
@@ -190,7 +190,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         expectation.expectedFulfillmentCount = 2
 
         var completedDownloads = 0
-        var results: [AFResult<Image>] = []
+        var results: [AFIResult<Image>] = []
 
         // When
         downloader.download([urlRequest1, urlRequest2], filter: nil) { closureResponse in
@@ -240,7 +240,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         let urlRequest = try! URLRequest(url: "https://httpbin.org/get", method: .get)
         let expectation = self.expectation(description: "download request should fail")
 
-        var response: DataResponse<Image>?
+        var response: AFIDataResponse<Image>?
 
         // When
         downloader.download(urlRequest) { closureResponse in
@@ -273,7 +273,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
-        var response: DataResponse<Image>?
+        var response: AFIDataResponse<Image>?
 
         // When
         downloader.download(urlRequest) { closureResponse in
@@ -302,7 +302,7 @@ class ImageDownloaderTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "image download should succeed")
 
-        var response: DataResponse<Image>?
+        var response: AFIDataResponse<Image>?
 
         // When
         downloader.download(urlRequest, filter: filter) { closureResponse in
@@ -335,8 +335,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         let expectation1 = expectation(description: "download request 1 should succeed")
         let expectation2 = expectation(description: "download request 2 should succeed")
 
-        var result1: AFResult<Image>?
-        var result2: AFResult<Image>?
+        var result1: AFIResult<Image>?
+        var result2: AFIResult<Image>?
 
         // When
         let requestReceipt1 = downloader.download(urlRequest1, filter: filter1) { closureResponse in
@@ -382,8 +382,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         let expectation1 = expectation(description: "download request 1 should succeed")
         let expectation2 = expectation(description: "download request 2 should succeed")
 
-        var result1: AFResult<Image>?
-        var result2: AFResult<Image>?
+        var result1: AFIResult<Image>?
+        var result2: AFIResult<Image>?
 
         // When
         let requestReceipt1 = downloader.download(urlRequest1, filter: filter1) { closureResponse in
@@ -490,7 +490,7 @@ class ImageDownloaderTestCase: BaseTestCase {
 
         let expectation = self.expectation(description: "download request should cancel")
 
-        var response: DataResponse<Image>?
+        var response: AFIDataResponse<Image>?
 
         // When
         let requestReceipt = downloader.download(urlRequest) { closureResponse in
@@ -509,7 +509,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         XCTAssertNil(response?.data, "data should be nil")
         XCTAssertTrue(response?.result.isFailure ?? false, "result should be a failure case")
 
-        if let error = response?.result.error as? AFIError {
+        if let error = response?.result.error {
             XCTAssertTrue(error.isRequestCancelledError)
         } else {
             XCTFail("error should not be nil")
@@ -526,8 +526,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         let expectation1 = expectation(description: "download request 1 should succeed")
         let expectation2 = expectation(description: "download request 2 should succeed")
 
-        var response1: DataResponse<Image>?
-        var response2: DataResponse<Image>?
+        var response1: AFIDataResponse<Image>?
+        var response2: AFIDataResponse<Image>?
 
         // When
         let requestReceipt1 = downloader.download(urlRequest1) { closureResponse in
@@ -553,7 +553,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         XCTAssertNil(response1?.data, "response 1 data should be nil")
         XCTAssertTrue(response1?.result.isFailure ?? false, "response 1 result should be a failure case")
 
-        if let error = response1?.result.error as? AFIError {
+        if let error = response1?.result.error {
             XCTAssertTrue(error.isRequestCancelledError)
         } else {
             XCTFail("error should not be nil")
@@ -578,8 +578,8 @@ class ImageDownloaderTestCase: BaseTestCase {
             "https://secure.gravatar.com/avatar/9a105e8b9d40e1329780d62ea2265d8a?d=identicon"
         ].map { URLRequest(url: URL(string: $0)!) }
 
-        var initialResults: [AFResult<Image>] = []
-        var finalResults: [AFResult<Image>] = []
+        var initialResults: [AFIResult<Image>] = []
+        var finalResults: [AFIResult<Image>] = []
 
         // When
         for (index, imageRequest) in imageRequests.enumerated() {
@@ -625,8 +625,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         for result in initialResults {
             XCTAssertTrue(result.isFailure)
 
-            if case let .failure(error) = result, let afiError = error as? AFIError {
-                XCTAssertTrue(afiError.isRequestCancelledError)
+            if case let .failure(error) = result {
+                XCTAssertTrue(error.isRequestCancelledError)
             } else {
                 XCTFail("error should not be nil")
             }
@@ -805,7 +805,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
-        var response: DataResponse<Image>?
+        var response: AFIDataResponse<Image>?
 
         // When
         downloader.download(urlRequest) { closureResponse in
@@ -828,8 +828,8 @@ class ImageDownloaderTestCase: BaseTestCase {
 
         let expectation1 = expectation(description: "image download should succeed")
 
-        var result1: AFResult<Image>?
-        var result2: AFResult<Image>?
+        var result1: AFIResult<Image>?
+        var result2: AFIResult<Image>?
 
         // When
         let requestReceipt1 = downloader.download(urlRequest) { closureResponse in
@@ -874,8 +874,8 @@ class ImageDownloaderTestCase: BaseTestCase {
 
         let expectation1 = expectation(description: "image download should succeed")
 
-        var result1: AFResult<Image>?
-        var result2: AFResult<Image>?
+        var result1: AFIResult<Image>?
+        var result2: AFIResult<Image>?
 
         // When
         let requestReceipt1 = downloader.download(urlRequest, filter: filter) { closureResponse in

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -65,7 +65,7 @@ class DataRequestTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/image/png"
         let expectation = self.expectation(description: "Request should return PNG response image")
 
-        var response: DataResponse<Image>?
+        var response: AFDataResponse<Image>?
 
         // When
         session.request(urlString)
@@ -101,7 +101,7 @@ class DataRequestTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/image/jpeg"
         let expectation = self.expectation(description: "Request should return JPG response image")
 
-        var response: DataResponse<Image>?
+        var response: AFDataResponse<Image>?
 
         // When
         session.request(urlString)
@@ -137,7 +137,7 @@ class DataRequestTestCase: BaseTestCase {
         let url = self.url(forResource: "apple", withExtension: "jpg")
         let expectation = self.expectation(description: "Request should return JPG response image")
 
-        var response: DataResponse<Image>?
+        var response: AFDataResponse<Image>?
 
         // When
         session.request(url)
@@ -177,7 +177,7 @@ class DataRequestTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/image/png"
         let expectation = self.expectation(description: "Request should return PNG response image")
 
-        var response: DataResponse<Image>?
+        var response: AFDataResponse<Image>?
 
         // When
         session.request(urlString)
@@ -209,7 +209,7 @@ class DataRequestTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/image/jpeg"
         let expectation = self.expectation(description: "Request should return JPG response image")
 
-        var response: DataResponse<Image>?
+        var response: AFDataResponse<Image>?
 
         // When
         session.request(urlString)
@@ -245,7 +245,7 @@ class DataRequestTestCase: BaseTestCase {
         let urlString = "https://invalid.for.sure"
         let expectation = self.expectation(description: "Request should fail with bad URL")
 
-        var response: DataResponse<Image>?
+        var response: AFDataResponse<Image>?
 
         // When
         session.request(urlString)
@@ -268,7 +268,7 @@ class DataRequestTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/image/webp"
         let expectation = self.expectation(description: "Request should return webp response image")
 
-        var response: DataResponse<Image>?
+        var response: AFDataResponse<Image>?
 
         // When
         session.request(urlString)
@@ -285,7 +285,7 @@ class DataRequestTestCase: BaseTestCase {
         XCTAssertTrue(response?.result.isFailure ?? false, "result should be failure")
         XCTAssertNotNil(response?.result.error, "result error should not be nil")
 
-        if let error = response?.result.error as? AFError {
+        if let error = response?.result.error {
             XCTAssertTrue(error.isUnacceptableContentType)
         } else {
             XCTFail("error should not be nil")
@@ -297,7 +297,7 @@ class DataRequestTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/bytes/0"
         let expectation = self.expectation(description: "Request should download no bytes")
 
-        var response: DataResponse<Image>?
+        var response: AFDataResponse<Image>?
 
         // When
         session.request(urlString)
@@ -314,7 +314,7 @@ class DataRequestTestCase: BaseTestCase {
         XCTAssertTrue(response?.result.isFailure ?? false, "result should be failure")
         XCTAssertNotNil(response?.result.error, "result error should not be nil")
 
-        if let error = response?.result.error as? AFError {
+        if let error = response?.result.error {
             XCTAssertTrue(error.isInputDataNilOrZeroLength)
         } else {
             XCTFail("error should not be nil")
@@ -327,7 +327,7 @@ class DataRequestTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/bytes/\(randomBytes)"
         let expectation = self.expectation(description: "Request should download random bytes")
 
-        var response: DataResponse<Image>?
+        var response: AFDataResponse<Image>?
 
         // When
         session.request(urlString)
@@ -344,7 +344,7 @@ class DataRequestTestCase: BaseTestCase {
         XCTAssertTrue(response?.result.isFailure ?? false, "result should be failure")
         XCTAssertNotNil(response?.result.error, "result error should not be nil")
 
-        if let error = response?.result.error as? AFError {
+        if let error = response?.result.error {
             XCTAssertTrue(error.isUnacceptableContentType)
         } else {
             XCTFail("error should not be nil")
@@ -356,7 +356,7 @@ class DataRequestTestCase: BaseTestCase {
         let urlString = "https://httpbin.org/get"
         let expectation = self.expectation(description: "Request should return JSON")
 
-        var response: DataResponse<Image>?
+        var response: AFDataResponse<Image>?
 
         // When
         session.request(urlString)
@@ -373,7 +373,7 @@ class DataRequestTestCase: BaseTestCase {
         XCTAssertTrue(response?.result.isFailure ?? false, "result should be failure")
         XCTAssertNotNil(response?.result.error, "result error should not be nil")
 
-        if let error = response?.result.error as? AFError {
+        if let error = response?.result.error {
             XCTAssertTrue(error.isUnacceptableContentType)
         } else {
             XCTFail("error should not be nil")

--- a/Tests/UIButtonTests.swift
+++ b/Tests/UIButtonTests.swift
@@ -109,7 +109,7 @@ class UIButtonTests: BaseTestCase {
         // Given
         let expectation = self.expectation(description: "image should cancel and download successfully")
         let button = UIButton()
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         button.af_setImage(for: [], url: url)
@@ -133,7 +133,7 @@ class UIButtonTests: BaseTestCase {
         // Given
         let expectation = self.expectation(description: "background image should cancel and download successfully")
         let button = UIButton()
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         button.af_setBackgroundImage(for: [], url: url)
@@ -558,7 +558,7 @@ class UIButtonTests: BaseTestCase {
         let expectation = self.expectation(description: "image download should succeed")
 
         var completionHandlerCalled = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         button.af_setImage(for: [], urlRequest: urlRequest, placeholderImage: nil) { response in
@@ -588,7 +588,7 @@ class UIButtonTests: BaseTestCase {
         let expectation = self.expectation(description: "image download should succeed")
 
         var completionHandlerCalled = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         button.af_setBackgroundImage(for: [], urlRequest: urlRequest, placeholderImage: nil) { response in
@@ -613,7 +613,7 @@ class UIButtonTests: BaseTestCase {
         let expectation = self.expectation(description: "image download should succeed")
 
         var completionHandlerCalled = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         button.af_setImage(for: [], urlRequest: urlRequest, placeholderImage: nil) { response in
@@ -638,7 +638,7 @@ class UIButtonTests: BaseTestCase {
         let expectation = self.expectation(description: "image download should succeed")
 
         var completionHandlerCalled = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         button.af_setBackgroundImage(for: [], urlRequest: urlRequest, placeholderImage: nil) { response in
@@ -665,7 +665,7 @@ class UIButtonTests: BaseTestCase {
         let expectation = self.expectation(description: "image download should succeed")
 
         var completionHandlerCalled = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         button.af_setImage(
@@ -696,7 +696,7 @@ class UIButtonTests: BaseTestCase {
         let expectation = self.expectation(description: "background image download should succeed")
 
         var completionHandlerCalled = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         button.af_setBackgroundImage(
@@ -726,7 +726,7 @@ class UIButtonTests: BaseTestCase {
 
         var completion1Called = false
         var completion2Called = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         button.af_setImage(
@@ -765,7 +765,7 @@ class UIButtonTests: BaseTestCase {
 
         var completion1Called = false
         var completion2Called = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         button.af_setBackgroundImage(
@@ -804,7 +804,7 @@ class UIButtonTests: BaseTestCase {
 
         var completion1Called = false
         var completion2Called = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         button.af_setImage(
@@ -845,7 +845,7 @@ class UIButtonTests: BaseTestCase {
 
         var completion1Called = false
         var completion2Called = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         button.af_setBackgroundImage(

--- a/Tests/UIImageViewTests.swift
+++ b/Tests/UIImageViewTests.swift
@@ -412,7 +412,7 @@ class UIImageViewTestCase: BaseTestCase {
         let expectation = self.expectation(description: "image download should succeed")
 
         var completionHandlerCalled = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         imageView.af_setImage(
@@ -443,7 +443,7 @@ class UIImageViewTestCase: BaseTestCase {
         let expectation = self.expectation(description: "image download should succeed")
 
         var completionHandlerCalled = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         imageView.af_setImage(
@@ -476,7 +476,7 @@ class UIImageViewTestCase: BaseTestCase {
         var completionHandlerCalled = false
         var transitionCompletionHandlerCalled = false
 
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         imageView.af_setImage(
@@ -528,7 +528,7 @@ class UIImageViewTestCase: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
 
         let cachedExpectation = expectation(description: "image should be cached")
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         imageView.af_setImage(
             withURLRequest: urlRequest,
@@ -558,7 +558,7 @@ class UIImageViewTestCase: BaseTestCase {
         let expectation = self.expectation(description: "image download should succeed")
 
         var completionHandlerCalled = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         imageView.af_setImage(
@@ -589,7 +589,7 @@ class UIImageViewTestCase: BaseTestCase {
 
         var completion1Called = false
         var completion2Called = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         imageView.af_setImage(
@@ -630,7 +630,7 @@ class UIImageViewTestCase: BaseTestCase {
 
         var completion1Called = false
         var completion2Called = false
-        var result: AFResult<UIImage>?
+        var result: AFIResult<UIImage>?
 
         // When
         imageView.af_setImage(
@@ -698,7 +698,7 @@ class UIImageViewTestCase: BaseTestCase {
 
         // When
         imageView.af_setImage(withURL: url)
-        let acceptField = imageView.af_activeRequestReceipt?.request.request?.allHTTPHeaderFields?["Accept"]
+        let acceptField = imageView.af_activeRequestReceipt?.request.request?.headers["Accept"]
         imageView.af_cancelImageRequest()
 
         // Then


### PR DESCRIPTION
### Issue Link :link:
#374 

### Goals :soccer:
This PR brings AFI up to date with Alamofire's RC changes.

### Implementation Details :construction:
A few changes were made to deal with the new doubly generic responses from Alamofire. 
- `AFIError` was updated with an `alamofireError` case which captures an `AFError`.
- `AFIDataResponse` was added as a `typealias` to make double generic use easier.
- `AFIResult` was also added for the same reason.

### Testing Details :mag:
Tests updated for the few cases where error casts are no longer needed.
