### PR TITLE
Tests for throwing URLRequestConvertible

### DIFF
--- a/AlamofireImage.xcodeproj/project.pbxproj
+++ b/AlamofireImage.xcodeproj/project.pbxproj
@@ -518,6 +518,9 @@
 		4CFB86631CA3656F007CE085 /* UIButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF24CF3C1C253CA000904E85 /* UIButtonTests.swift */; };
 		4CFC0A061AB4FEC90004D0B8 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFC0A051AB4FEC90004D0B8 /* ImageCache.swift */; };
 		4CFC0A091AB52BD90004D0B8 /* ImageFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFC0A081AB52BD90004D0B8 /* ImageFilter.swift */; };
+		B30AFF7D23F4A3FB00883238 /* ThrowingURLRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30AFF7B23F49CC500883238 /* ThrowingURLRequestConvertible.swift */; };
+		B30AFF7E23F4A3FC00883238 /* ThrowingURLRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30AFF7B23F49CC500883238 /* ThrowingURLRequestConvertible.swift */; };
+		B30AFF7F23F4A3FD00883238 /* ThrowingURLRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30AFF7B23F49CC500883238 /* ThrowingURLRequestConvertible.swift */; };
 		CF24CF421C253CB100904E85 /* UIButton+AlamofireImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF24CF411C253CB100904E85 /* UIButton+AlamofireImage.swift */; };
 		CF24CF461C253D4F00904E85 /* UIButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF24CF3C1C253CA000904E85 /* UIButtonTests.swift */; };
 /* End PBXBuildFile section */
@@ -757,6 +760,7 @@
 		4CEBB53F1B93C622001391DE /* ImageCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheTests.swift; sourceTree = "<group>"; };
 		4CFC0A051AB4FEC90004D0B8 /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		4CFC0A081AB52BD90004D0B8 /* ImageFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageFilter.swift; sourceTree = "<group>"; };
+		B30AFF7B23F49CC500883238 /* ThrowingURLRequestConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrowingURLRequestConvertible.swift; sourceTree = "<group>"; };
 		CF24CF3C1C253CA000904E85 /* UIButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonTests.swift; sourceTree = "<group>"; };
 		CF24CF411C253CB100904E85 /* UIButton+AlamofireImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIButton+AlamofireImage.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1257,6 +1261,7 @@
 				CF24CF3C1C253CA000904E85 /* UIButtonTests.swift */,
 				4C0893F41B937404005125D9 /* UIImageTests.swift */,
 				4C62D30F1B96C1500011B036 /* UIImageViewTests.swift */,
+				B30AFF7A23F49CC500883238 /* TestEnvironment */,
 				4C0893EA1B936A4D005125D9 /* Extensions */,
 				4CBE8FB52316006100782A2E /* Stress Tests */,
 			);
@@ -1288,6 +1293,14 @@
 				4CE611541AABC8D900D35044 /* Request+AlamofireImage.swift */,
 			);
 			name = Alamofire;
+			sourceTree = "<group>";
+		};
+		B30AFF7A23F49CC500883238 /* TestEnvironment */ = {
+			isa = PBXGroup;
+			children = (
+				B30AFF7B23F49CC500883238 /* ThrowingURLRequestConvertible.swift */,
+			);
+			path = TestEnvironment;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2074,6 +2087,7 @@
 				4C16B3AE1BA93ADB00A66EF0 /* UIImage+AlamofireImageTests.swift in Sources */,
 				4C16B3AA1BA93ADB00A66EF0 /* ImageFilterTests.swift in Sources */,
 				4C16B3A71BA93ADB00A66EF0 /* BaseTestCase.swift in Sources */,
+				B30AFF7F23F4A3FD00883238 /* ThrowingURLRequestConvertible.swift in Sources */,
 				4CBE8FB92316008300782A2E /* ImageDownloaderStressTests.swift in Sources */,
 				4C16B3AD1BA93ADB00A66EF0 /* UIImageViewTests.swift in Sources */,
 				4C16B3A91BA93ADB00A66EF0 /* ImageDownloaderTests.swift in Sources */,
@@ -2125,6 +2139,7 @@
 				4C5872CA1B93DEAC00407E58 /* ImageFilterTests.swift in Sources */,
 				4CEBB5401B93C622001391DE /* ImageCacheTests.swift in Sources */,
 				4C0893EC1B936A7A005125D9 /* UIImage+AlamofireImageTests.swift in Sources */,
+				B30AFF7D23F4A3FB00883238 /* ThrowingURLRequestConvertible.swift in Sources */,
 				4CBE8FB72316008300782A2E /* ImageDownloaderStressTests.swift in Sources */,
 				4C1624851AABE8E600A0385D /* BaseTestCase.swift in Sources */,
 				4C0893F51B937404005125D9 /* UIImageTests.swift in Sources */,
@@ -2160,6 +2175,7 @@
 				4C1624861AABE8E600A0385D /* BaseTestCase.swift in Sources */,
 				4CEBB5411B93C622001391DE /* ImageCacheTests.swift in Sources */,
 				4C86C1121DA0B3400032ECC3 /* UIImageViewTests.swift in Sources */,
+				B30AFF7E23F4A3FC00883238 /* ThrowingURLRequestConvertible.swift in Sources */,
 				4CBE8FB82316008300782A2E /* ImageDownloaderStressTests.swift in Sources */,
 				4C5874871B93F81800407E58 /* ImageDownloaderTests.swift in Sources */,
 				4C86C1131DA0B3440032ECC3 /* UIImage+AlamofireImageTests.swift in Sources */,

--- a/Tests/TestEnvironment/ThrowingURLRequestConvertible.swift
+++ b/Tests/TestEnvironment/ThrowingURLRequestConvertible.swift
@@ -1,0 +1,21 @@
+//
+//  ThrowingURLRequestConvertible.swift
+//  AlamofireImage iOS
+//
+//  Created by Marina Gornostaeva on 10/02/2020.
+//  Copyright © 2020 Alamofire. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+struct ThrowingURLRequestConvertible: URLRequestConvertible {
+    
+    enum Error: Swift.Error {
+        case testError
+    }
+    
+    func asURLRequest() throws -> URLRequest {
+        throw Error.testError
+    }
+}

--- a/Tests/UIButtonTests.swift
+++ b/Tests/UIButtonTests.swift
@@ -514,6 +514,33 @@ class UIButtonTests: BaseTestCase {
         XCTAssertNotNil(button.backgroundImage(for: []), "button background image should not be nil")
         XCTAssertFalse(button.backgroundImage(for:[]) === placeholderImage, "button background image should not equal placeholder image")
     }
+    
+    func testThatPlaceholderImageIsDisplayedWithThrowingURLConvertible() {
+        // Given
+        let placeholderImage = image(forResource: "pirate", withExtension: "jpg")
+        let button = TestButton ()
+        
+        // When
+        button.af_setImage(for: [], url: url, placeholderImage: placeholderImage)
+        let initialImageEqualsPlaceholderImage = button.image(for:[]) === placeholderImage
+        
+        // Then
+        XCTAssertTrue(initialImageEqualsPlaceholderImage, "initial image should equal placeholder image")
+    }
+
+    func testThatBackgroundPlaceholderImageIsDisplayedWithThrowingURLConvertible() {
+        // Given
+        let placeholderImage = image(forResource: "pirate", withExtension: "jpg")
+        let button = TestButton ()
+
+        // When
+        button.af_setBackgroundImage(for: [], url: url, placeholderImage: placeholderImage)
+        let initialImageEqualsPlaceholderImage = button.backgroundImage(for:[]) === placeholderImage
+
+        // Then
+        XCTAssertTrue(initialImageEqualsPlaceholderImage, "initial image should equal placeholder image")
+    }
+
 
     // MARK: - Image Filters
 
@@ -610,7 +637,7 @@ class UIButtonTests: BaseTestCase {
         let button = UIButton()
         let urlRequest = URLRequest(url: URL(string: "really-bad-domain")!)
 
-        let expectation = self.expectation(description: "image download should succeed")
+        let expectation = self.expectation(description: "image download should complete")
 
         var completionHandlerCalled = false
         var result: AFIResult<UIImage>?
@@ -635,7 +662,57 @@ class UIButtonTests: BaseTestCase {
         let button = UIButton()
         let urlRequest = URLRequest(url: URL(string: "really-bad-domain")!)
 
-        let expectation = self.expectation(description: "image download should succeed")
+        let expectation = self.expectation(description: "image download should complete")
+
+        var completionHandlerCalled = false
+        var result: AFIResult<UIImage>?
+
+        // When
+        button.af_setBackgroundImage(for: [], urlRequest: urlRequest, placeholderImage: nil) { response in
+            completionHandlerCalled = true
+            result = response.result
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertTrue(completionHandlerCalled, "completion handler called should be true")
+        XCTAssertNil(button.backgroundImage(for: []), "button background image should be nil")
+        XCTAssertTrue(result?.isFailure ?? false, "result should be a failure case")
+    }
+    
+    func testThatCompletionHandlerIsCalledWhenURLRequestConvertibleThrows() {
+        // Given
+        let button = UIButton()
+        let urlRequest = ThrowingURLRequestConvertible()
+
+        let expectation = self.expectation(description: "image download should complete")
+
+        var completionHandlerCalled = false
+        var result: AFIResult<UIImage>?
+
+        // When
+        button.af_setImage(for: [], urlRequest: urlRequest, placeholderImage: nil) { response in
+            completionHandlerCalled = true
+            result = response.result
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertTrue(completionHandlerCalled, "completion handler called should be true")
+        XCTAssertNil(button.image(for: []), "button image should be nil")
+        XCTAssertTrue(result?.isFailure ?? false, "result should be a failure case")
+    }
+
+    func testThatCompletionHandlerIsCalledWhenBackgroundImageURLRequestConvertibleThrows() {
+        // Given
+        let button = UIButton()
+        let urlRequest = ThrowingURLRequestConvertible()
+
+        let expectation = self.expectation(description: "image download should complete")
 
         var completionHandlerCalled = false
         var result: AFIResult<UIImage>?

--- a/Tests/UIImageViewTests.swift
+++ b/Tests/UIImageViewTests.swift
@@ -248,6 +248,19 @@ class UIImageViewTestCase: BaseTestCase {
         XCTAssertTrue(initialImageEqualsPlaceholderImage, "initial image should equal placeholder image")
         XCTAssertFalse(finalImageEqualsPlaceholderImage, "final image should not equal placeholder image")
     }
+    
+    func testThatPlaceholderImageIsDisplayedWithThrowingURLConvertible() {
+        // Given
+        let placeholderImage = image(forResource: "pirate", withExtension: "jpg")
+        let imageView = TestImageView()
+
+        // When
+        imageView.af_setImage(withURLRequest: ThrowingURLRequestConvertible(), placeholderImage: placeholderImage)
+        let initialImageEqualsPlaceholderImage = imageView.image === placeholderImage
+
+        // Then
+        XCTAssertTrue(initialImageEqualsPlaceholderImage, "initial image should equal placeholder image")
+    }
 
     func testThatPlaceholderIsNeverDisplayedIfCachedImageIsAvailable() {
         // Given
@@ -440,7 +453,7 @@ class UIImageViewTestCase: BaseTestCase {
         let imageView = UIImageView()
         let urlRequest = URLRequest(url: URL(string: "domain-name-does-not-exist")!)
 
-        let expectation = self.expectation(description: "image download should succeed")
+        let expectation = self.expectation(description: "image download should complete")
 
         var completionHandlerCalled = false
         var result: AFIResult<UIImage>?
@@ -464,6 +477,37 @@ class UIImageViewTestCase: BaseTestCase {
         XCTAssertTrue(completionHandlerCalled, "completion handler called should be true")
         XCTAssertNil(imageView.image, "image view image should be nil when completion handler is not nil")
         XCTAssertTrue(result?.isFailure ?? false, "result should be a failure case")
+    }
+    
+    func testThatCompletionHandlerIsCalledWhenURLRequestConvertibleThrows() {
+        // Given
+        let imageView = UIImageView()
+        let urlRequest = ThrowingURLRequestConvertible()
+
+        let expectation = self.expectation(description: "image download should complete")
+
+        var completionHandlerCalled = false
+        var result: AFIResult<UIImage>?
+
+        // When
+        imageView.af_setImage(
+            withURLRequest: urlRequest,
+            placeholderImage: nil,
+            filter: nil,
+            imageTransition: .noTransition,
+            completion: { closureResponse in
+                completionHandlerCalled = true
+                result = closureResponse.result
+                expectation.fulfill()
+            }
+        )
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertTrue(completionHandlerCalled, "completion handler called should be true")
+        XCTAssertNil(imageView.image, "image view image should be nil when completion handler is not nil")
+        XCTAssertEqual(result?.isFailure, true, "result should be a failure case")
     }
 
     func testThatCompletionHandlerAndCustomTransitionHandlerAreBothCalled() {


### PR DESCRIPTION
### Issue Link :link:

Unit tests for #241

### Goals :soccer:

Ensure the library correctly supports throwing `URLRequestConvertible` requests

### Implementation Details :construction:

I've started fixing #241 but then noticed that a fix is already present on master. I already added the tests at that point, so hope these are useful still.

- Added corresponding tests for `ImageDownloader`, `UIButton` and `UIImageView` extensions
- Minor code refactoring in `ImageDownloader` to make it easier to understand and make it safer - preventing variable shadowing that can confuse the reader. 

### Testing Details :mag:

The PR mainly contains new tests for pre-existing functionality, and the minor refactoring in `ImageDownloader` is covered by existing tests which pass. 
There are couple of failing tests which seem to be failing on master too.