### PR TITLE
Optional completion handler

### DIFF
--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -280,7 +280,7 @@ open class ImageDownloader {
                        filter: ImageFilter? = nil,
                        progress: ProgressHandler? = nil,
                        progressQueue: DispatchQueue = DispatchQueue.main,
-                       completion: CompletionHandler?)
+                       completion: CompletionHandler? = nil)
         -> RequestReceipt? {
         var queuedRequest: DataRequest?
 


### PR DESCRIPTION
### Goals :soccer:

The goals are:

* More concise API:

    When downloading images (e.g. as part of a prefetch process), you don’t need a completion handler closure, but right now we have to supply one although the parameter is optional. For example, if you don’t have a completion handler, you have to do:

      imageDownloader.download(request, completion: nil)

    With this change, we can omit that `completion` parameter entirely:

      imageDownloader.download(request)

* More consistent API:

    Everywhere else in the API, the optional completion handlers have a default value of `nil`. But the `download` method of `ImageDownloader` does not.

### Implementation Details :construction:

Just supplied a default parameter of `nil` for the completion handler for this one method.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
