### PR TITLE
Reduce url copypaste in tests 

### DIFF
--- a/AlamofireImage.xcodeproj/project.pbxproj
+++ b/AlamofireImage.xcodeproj/project.pbxproj
@@ -510,6 +510,9 @@
 		B30AFF7D23F4A3FB00883238 /* ThrowingURLRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30AFF7B23F49CC500883238 /* ThrowingURLRequestConvertible.swift */; };
 		B30AFF7E23F4A3FC00883238 /* ThrowingURLRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30AFF7B23F49CC500883238 /* ThrowingURLRequestConvertible.swift */; };
 		B30AFF7F23F4A3FD00883238 /* ThrowingURLRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30AFF7B23F49CC500883238 /* ThrowingURLRequestConvertible.swift */; };
+		B3A66806243D154800BAB708 /* TestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A66804243D153E00BAB708 /* TestEnvironment.swift */; };
+		B3A66807243D154F00BAB708 /* TestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A66804243D153E00BAB708 /* TestEnvironment.swift */; };
+		B3A66808243D155000BAB708 /* TestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A66804243D153E00BAB708 /* TestEnvironment.swift */; };
 		CF24CF421C253CB100904E85 /* UIButton+AlamofireImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF24CF411C253CB100904E85 /* UIButton+AlamofireImage.swift */; };
 		CF24CF461C253D4F00904E85 /* UIButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF24CF3C1C253CA000904E85 /* UIButtonTests.swift */; };
 /* End PBXBuildFile section */
@@ -752,6 +755,7 @@
 		4CFC0A051AB4FEC90004D0B8 /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		4CFC0A081AB52BD90004D0B8 /* ImageFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageFilter.swift; sourceTree = "<group>"; };
 		B30AFF7B23F49CC500883238 /* ThrowingURLRequestConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrowingURLRequestConvertible.swift; sourceTree = "<group>"; };
+		B3A66804243D153E00BAB708 /* TestEnvironment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEnvironment.swift; sourceTree = "<group>"; };
 		CF24CF3C1C253CA000904E85 /* UIButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonTests.swift; sourceTree = "<group>"; };
 		CF24CF411C253CB100904E85 /* UIButton+AlamofireImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIButton+AlamofireImage.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -956,6 +960,7 @@
 		4C54EE941AABC08B00CD894C /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				B3A66803243D153E00BAB708 /* TestEnvironment */,
 				4CD5BCF31D7FBE1C0055E232 /* Extensions */,
 				4CBE9C642401FE2100B2AAC0 /* Helpers */,
 				4C0894021B9382EB005125D9 /* Resources */,
@@ -1286,6 +1291,14 @@
 				4CE611541AABC8D900D35044 /* Request+AlamofireImage.swift */,
 			);
 			name = Alamofire;
+			sourceTree = "<group>";
+		};
+		B3A66803243D153E00BAB708 /* TestEnvironment */ = {
+			isa = PBXGroup;
+			children = (
+				B3A66804243D153E00BAB708 /* TestEnvironment.swift */,
+			);
+			path = TestEnvironment;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2051,6 +2064,7 @@
 				4CD5BCF71D7FBE380055E232 /* AFError+AlamofireImageTests.swift in Sources */,
 				4C16B3AB1BA93ADB00A66EF0 /* RequestTests.swift in Sources */,
 				4CFB86631CA3656F007CE085 /* UIButtonTests.swift in Sources */,
+				B3A66808243D155000BAB708 /* TestEnvironment.swift in Sources */,
 				4C7DD7F1224EC07000249836 /* AFResult+AlamofireImageTests.swift in Sources */,
 				4C16B3A81BA93ADB00A66EF0 /* ImageCacheTests.swift in Sources */,
 				4C16B3AE1BA93ADB00A66EF0 /* UIImage+AlamofireImageTests.swift in Sources */,
@@ -2103,6 +2117,7 @@
 				4CD5BCF51D7FBE380055E232 /* AFError+AlamofireImageTests.swift in Sources */,
 				4C62D3101B96C1500011B036 /* UIImageViewTests.swift in Sources */,
 				CF24CF461C253D4F00904E85 /* UIButtonTests.swift in Sources */,
+				B3A66806243D154800BAB708 /* TestEnvironment.swift in Sources */,
 				4C7DD7EF224EC07000249836 /* AFResult+AlamofireImageTests.swift in Sources */,
 				4C0897EB1B93BC0D005125D9 /* RequestTests.swift in Sources */,
 				4C5872CA1B93DEAC00407E58 /* ImageFilterTests.swift in Sources */,
@@ -2139,6 +2154,7 @@
 				4CD5BCF61D7FBE380055E232 /* AFError+AlamofireImageTests.swift in Sources */,
 				4C86C1111DA0B33C0032ECC3 /* UIImageTests.swift in Sources */,
 				4C86C10F1DA0B3340032ECC3 /* ImageFilterTests.swift in Sources */,
+				B3A66807243D154F00BAB708 /* TestEnvironment.swift in Sources */,
 				4C7DD7F0224EC07000249836 /* AFResult+AlamofireImageTests.swift in Sources */,
 				4C86C1101DA0B3390032ECC3 /* UIButtonTests.swift in Sources */,
 				4C1624861AABE8E600A0385D /* BaseTestCase.swift in Sources */,

--- a/Tests/ImageCacheTests.swift
+++ b/Tests/ImageCacheTests.swift
@@ -76,7 +76,7 @@ final class ImageCacheTestCase: BaseTestCase {
     func testThatItCanAddImageToCacheWithRequestIdentifier() {
         // Given
         let image = self.image(forResource: "unicorn", withExtension: "png")
-        let request = try! URLRequest(url: "https://images.example.com/animals", method: .get)
+        let request = try! URLRequest(url: TestEnvironment.URL.nonExistent, method: .get)
         let identifier = "-unicorn"
 
         // When
@@ -114,7 +114,7 @@ final class ImageCacheTestCase: BaseTestCase {
         // Given
         let unicornImage = image(forResource: "unicorn", withExtension: "png")
         let pirateImage = image(forResource: "pirate", withExtension: "jpg")
-        let request = try! URLRequest(url: "https://images.example.com/animals", method: .get)
+        let request = try! URLRequest(url: TestEnvironment.URL.nonExistent, method: .get)
         let identifier = "animal"
 
         // When
@@ -156,7 +156,7 @@ final class ImageCacheTestCase: BaseTestCase {
     func testThatItCanRemoveImageFromCacheWithRequestIdentifier() {
         // Given
         let image = self.image(forResource: "unicorn", withExtension: "png")
-        let request = try! URLRequest(url: "https://images.example.com/animals", method: .get)
+        let request = try! URLRequest(url: TestEnvironment.URL.nonExistent, method: .get)
         let identifier = "unicorn"
 
         // When
@@ -175,7 +175,7 @@ final class ImageCacheTestCase: BaseTestCase {
     func testThatItCanRemoveImagesFromCacheMatchingRequestIdentifier() {
         // Given
         let image = self.image(forResource: "unicorn", withExtension: "png")
-        let request = try! URLRequest(url: "https://images.example.com/animals", method: .get)
+        let request = try! URLRequest(url: TestEnvironment.URL.nonExistent, method: .get)
 
         let identifier1 = "unicorn-100"
         let identifier2 = "unicorn-400"
@@ -261,7 +261,7 @@ final class ImageCacheTestCase: BaseTestCase {
     func testThatItCanFetchImageFromCacheWithRequestIdentifier() {
         // Given
         let image = self.image(forResource: "unicorn", withExtension: "png")
-        let request = try! URLRequest(url: "https://images.example.com/animals", method: .get)
+        let request = try! URLRequest(url: TestEnvironment.URL.nonExistent, method: .get)
         let identifier = "unicorn"
 
         // When

--- a/Tests/ImageDownloaderStressTests.swift
+++ b/Tests/ImageDownloaderStressTests.swift
@@ -184,10 +184,7 @@ class ImageDownloaderStressTestCase: BaseTestCase {
     }
 
     private func uniqueKittenURLString() -> String {
-        let width = Int.random(in: 100...400)
-        let height = Int.random(in: 100...400)
-
-        let urlString = "https://placekitten.com/\(width)/\(height)"
+        let urlString = TestEnvironment.URL.kittenImageOfRandomSize
 
         if kittenCache.contains(urlString) {
             return uniqueKittenURLString()

--- a/Tests/ImageDownloaderTests.swift
+++ b/Tests/ImageDownloaderTests.swift
@@ -101,7 +101,7 @@ class ImageDownloaderTestCase: BaseTestCase {
 
     func testThatImageDownloaderCanBeInitializedAndDeinitializedWithActiveDownloads() {
         // Given
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/png", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.pngImage, method: .get)
         var downloader: ImageDownloader? = ImageDownloader()
 
         // When
@@ -120,7 +120,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCanDownloadAnImage() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         var response: AFIDataResponse<Image>?
@@ -144,8 +144,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let urlRequest1 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
-        let urlRequest2 = try! URLRequest(url: "https://httpbin.org/image/png", method: .get)
+        let urlRequest1 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
+        let urlRequest2 = try! URLRequest(url: TestEnvironment.URL.pngImage, method: .get)
 
         let expectation1 = expectation(description: "download 1 should succeed")
         let expectation2 = expectation(description: "download 2 should succeed")
@@ -182,8 +182,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let urlRequest1 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
-        let urlRequest2 = try! URLRequest(url: "https://httpbin.org/image/png", method: .get)
+        let urlRequest1 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
+        let urlRequest2 = try! URLRequest(url: TestEnvironment.URL.pngImage, method: .get)
 
         let expectation = self.expectation(description: "both downloads should succeed")
         expectation.expectedFulfillmentCount = 2
@@ -213,8 +213,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader(maximumActiveDownloads: 1)
 
-        let urlRequest1 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
-        let urlRequest2 = try! URLRequest(url: "https://httpbin.org/image/png", method: .get)
+        let urlRequest1 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
+        let urlRequest2 = try! URLRequest(url: TestEnvironment.URL.pngImage, method: .get)
 
         // When
         let requestReceipt1 = downloader.download(urlRequest1) { _ in
@@ -236,7 +236,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCallsTheCompletionHandlerEvenWhenDownloadFails() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/get", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.json, method: .get)
         let expectation = self.expectation(description: "download request should fail")
 
         var response: AFIDataResponse<Image>?
@@ -291,7 +291,7 @@ class ImageDownloaderTestCase: BaseTestCase {
             return downloader
         }()
 
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         var response: AFIDataResponse<Image>?
@@ -317,7 +317,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCanDownloadImageAndApplyImageFilter() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
         let scaledSize = CGSize(width: 100, height: 60)
         let filter = ScaledToSizeFilter(size: scaledSize)
 
@@ -347,8 +347,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let urlRequest1 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
-        let urlRequest2 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest1 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
+        let urlRequest2 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
 
         let filter1 = ScaledToSizeFilter(size: CGSize(width: 50, height: 50))
         let filter2 = ScaledToSizeFilter(size: CGSize(width: 75, height: 75))
@@ -394,8 +394,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let urlRequest1 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
-        let urlRequest2 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest1 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
+        let urlRequest2 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
 
         let filter1 = TestCircleFilter()
         let filter2 = TestCircleFilter()
@@ -439,7 +439,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCallsTheProgressHandlerOnTheMainQueueByDefault() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
 
         let progressExpectation = expectation(description: "progress closure should be called")
         let completedExpectation = expectation(description: "download request should succeed")
@@ -469,7 +469,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCallsTheProgressHandlerOnTheProgressQueue() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
 
         let progressExpectation = expectation(description: "progress closure should be called")
         let completedExpectation = expectation(description: "download request should succeed")
@@ -503,7 +503,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatCancellingDownloadCallsCompletionWithCancellationError() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
 
         let expectation = self.expectation(description: "download request should cancel")
 
@@ -536,8 +536,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let urlRequest1 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
-        let urlRequest2 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest1 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
+        let urlRequest2 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
 
         let expectation1 = expectation(description: "download request 1 should succeed")
         let expectation2 = expectation(description: "download request 2 should succeed")
@@ -586,11 +586,7 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let imageRequests: [URLRequest] = ["https://secure.gravatar.com/avatar/5a105e8b9d40e1329780d62ea2265d8a?d=identicon",
-                                           "https://secure.gravatar.com/avatar/6a105e8b9d40e1329780d62ea2265d8a?d=identicon",
-                                           "https://secure.gravatar.com/avatar/7a105e8b9d40e1329780d62ea2265d8a?d=identicon",
-                                           "https://secure.gravatar.com/avatar/8a105e8b9d40e1329780d62ea2265d8a?d=identicon",
-                                           "https://secure.gravatar.com/avatar/9a105e8b9d40e1329780d62ea2265d8a?d=identicon"].map { URLRequest(url: URL(string: $0)!) }
+        let imageRequests: [URLRequest] = TestEnvironment.URL.gravatarImages.map { URLRequest(url: URL(string: $0)!) }
 
         var initialResults: [AFIResult<Image>] = []
         var finalResults: [AFIResult<Image>] = []
@@ -656,7 +652,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItDoesNotAttachAuthenticationCredentialToRequestIfItDoesNotExist() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
 
         // When
         let requestReceipt = downloader.download(urlRequest) { _ in
@@ -673,7 +669,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItAttachsUsernamePasswordCredentialToRequestIfItExists() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
 
         // When
         downloader.addAuthentication(user: "foo", password: "bar")
@@ -692,7 +688,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItAttachsAuthenticationCredentialToRequestIfItExists() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
 
         // When
         let credential = URLCredential(user: "foo", password: "bar", persistence: .forSession)
@@ -714,7 +710,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCallsTheCompletionHandlerOnTheMainQueue() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
 
         let expectation = self.expectation(description: "download request should succeed")
 
@@ -777,7 +773,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItNeverCallsTheImageFilterOnTheMainQueue() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
         let filter = ThreadCheckFilter()
 
         let expectation = self.expectation(description: "download request should succeed")
@@ -798,7 +794,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatCachedImageIsReturnedIfAllowedByCachePolicy() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest1 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest1 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
 
         let expectation1 = expectation(description: "image download should succeed")
 
@@ -809,7 +805,7 @@ class ImageDownloaderTestCase: BaseTestCase {
 
         waitForExpectations(timeout: timeout, handler: nil)
 
-        var urlRequest2 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        var urlRequest2 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
         urlRequest2.cachePolicy = .returnCacheDataElseLoad
 
         let expectation2 = expectation(description: "image download should succeed")
@@ -828,7 +824,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatCachedImageIsNotReturnedIfNotAllowedByCachePolicy() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest1 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest1 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
 
         let expectation1 = expectation(description: "image download should succeed")
 
@@ -839,7 +835,7 @@ class ImageDownloaderTestCase: BaseTestCase {
 
         waitForExpectations(timeout: timeout, handler: nil)
 
-        var urlRequest2 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        var urlRequest2 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
         urlRequest2.cachePolicy = .reloadIgnoringLocalCacheData
 
         let expectation2 = expectation(description: "image download should succeed")
@@ -858,7 +854,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItCanDownloadImagesWhenNoImageCacheIsAvailable() {
         // Given
         let downloader = ImageDownloader(imageCache: nil)
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         var response: AFIDataResponse<Image>?
@@ -880,7 +876,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatItAutomaticallyCachesDownloadedImageIfCacheIsAvailable() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
 
         let expectation1 = expectation(description: "image download should succeed")
 
@@ -924,7 +920,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatFilteredImageIsStoredInCacheIfCacheIsAvailable() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
         let size = CGSize(width: 20, height: 20)
         let filter = ScaledToSizeFilter(size: size)
 
@@ -976,7 +972,7 @@ class ImageDownloaderTestCase: BaseTestCase {
     func testThatStartingRequestIncrementsActiveRequestCount() {
         // Given
         let downloader = ImageDownloader()
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
         let request = downloader.session.request(urlRequest)
 
         // When
@@ -995,8 +991,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader()
 
-        let urlRequest1 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
-        let urlRequest2 = try! URLRequest(url: "https://httpbin.org/image/png", method: .get)
+        let urlRequest1 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
+        let urlRequest2 = try! URLRequest(url: TestEnvironment.URL.pngImage, method: .get)
 
         let request1 = downloader.session.request(urlRequest1)
         let request2 = downloader.session.request(urlRequest2)
@@ -1017,8 +1013,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader(downloadPrioritization: .lifo)
 
-        let urlRequest1 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
-        let urlRequest2 = try! URLRequest(url: "https://httpbin.org/image/png", method: .get)
+        let urlRequest1 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
+        let urlRequest2 = try! URLRequest(url: TestEnvironment.URL.pngImage, method: .get)
 
         let request1 = downloader.session.request(urlRequest1)
         let request2 = downloader.session.request(urlRequest2)
@@ -1039,8 +1035,8 @@ class ImageDownloaderTestCase: BaseTestCase {
         // Given
         let downloader = ImageDownloader(downloadPrioritization: .fifo)
 
-        let urlRequest1 = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
-        let urlRequest2 = try! URLRequest(url: "https://httpbin.org/image/png", method: .get)
+        let urlRequest1 = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
+        let urlRequest2 = try! URLRequest(url: TestEnvironment.URL.pngImage, method: .get)
 
         let request1 = downloader.session.request(urlRequest1)
         let request2 = downloader.session.request(urlRequest2)

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -62,7 +62,7 @@ class DataRequestTestCase: BaseTestCase {
 
     func testThatImageResponseSerializerCanDownloadPNGImage() {
         // Given
-        let urlString = "https://httpbin.org/image/png"
+        let urlString = TestEnvironment.URL.pngImage
         let expectation = self.expectation(description: "Request should return PNG response image")
 
         var response: AFDataResponse<Image>?
@@ -98,7 +98,7 @@ class DataRequestTestCase: BaseTestCase {
 
     func testThatImageResponseSerializerCanDownloadJPGImage() {
         // Given
-        let urlString = "https://httpbin.org/image/jpeg"
+        let urlString = TestEnvironment.URL.jpegImage
         let expectation = self.expectation(description: "Request should return JPG response image")
 
         var response: AFDataResponse<Image>?
@@ -174,7 +174,7 @@ class DataRequestTestCase: BaseTestCase {
 
     func testThatImageResponseSerializerCanDownloadAndInflatePNGImage() {
         // Given
-        let urlString = "https://httpbin.org/image/png"
+        let urlString = TestEnvironment.URL.pngImage
         let expectation = self.expectation(description: "Request should return PNG response image")
 
         var response: AFDataResponse<Image>?
@@ -206,7 +206,7 @@ class DataRequestTestCase: BaseTestCase {
 
     func testThatImageResponseSerializerCanDownloadAndInflateJPGImage() {
         // Given
-        let urlString = "https://httpbin.org/image/jpeg"
+        let urlString = TestEnvironment.URL.jpegImage
         let expectation = self.expectation(description: "Request should return JPG response image")
 
         var response: AFDataResponse<Image>?
@@ -242,7 +242,7 @@ class DataRequestTestCase: BaseTestCase {
 
     func testThatAttemptingToDownloadImageFromBadURLReturnsFailureResult() {
         // Given
-        let urlString = "https://invalid.for.sure"
+        let urlString = TestEnvironment.URL.nonExistent
         let expectation = self.expectation(description: "Request should fail with bad URL")
 
         var response: AFDataResponse<Image>?
@@ -265,7 +265,7 @@ class DataRequestTestCase: BaseTestCase {
 
     func testThatAttemptingToDownloadUnsupportedImageTypeReturnsFailureResult() {
         // Given
-        let urlString = "https://httpbin.org/image/webp"
+        let urlString = TestEnvironment.URL.webpImage
         let expectation = self.expectation(description: "Request should return webp response image")
 
         var response: AFDataResponse<Image>?
@@ -294,7 +294,7 @@ class DataRequestTestCase: BaseTestCase {
 
     func testThatAttemptingToSerializeEmptyDataReturnsFailureResult() {
         // Given
-        let urlString = "https://httpbin.org/bytes/0"
+        let urlString = TestEnvironment.URL.zeroBytes
         let expectation = self.expectation(description: "Request should download no bytes")
 
         var response: AFDataResponse<Image>?
@@ -323,8 +323,7 @@ class DataRequestTestCase: BaseTestCase {
 
     func testThatAttemptingToSerializeRandomStreamDataReturnsFailureResult() {
         // Given
-        let randomBytes = 4 * 1024 * 1024
-        let urlString = "https://httpbin.org/bytes/\(randomBytes)"
+        let urlString = TestEnvironment.URL.randomBytes
         let expectation = self.expectation(description: "Request should download random bytes")
 
         var response: AFDataResponse<Image>?
@@ -353,7 +352,7 @@ class DataRequestTestCase: BaseTestCase {
 
     func testThatAttemptingToSerializeJSONResponseIntoImageReturnsFailureResult() {
         // Given
-        let urlString = "https://httpbin.org/get"
+        let urlString = TestEnvironment.URL.json
         let expectation = self.expectation(description: "Request should return JSON")
 
         var response: AFDataResponse<Image>?

--- a/Tests/TestEnvironment/TestEnvironment.swift
+++ b/Tests/TestEnvironment/TestEnvironment.swift
@@ -1,0 +1,45 @@
+//
+//  TestEnvironment.swift
+//  AlamofireImage
+//
+//  Created by Marina Gornostaeva on 12/02/2020.
+//  Copyright © 2020 Alamofire. All rights reserved.
+//
+
+import Foundation
+
+enum TestEnvironment {
+    
+    enum URL {
+        static let pngImage = "https://httpbin.org/image/png"
+        static let jpegImage = "https://httpbin.org/image/jpeg"
+        static let pngImageWithRedirect = "https://httpbin.org/redirect-to?url=\(URL.pngImage)"
+        static let webpImage = "https://httpbin.org/image/webp"
+        
+        static let zeroBytes = "https://httpbin.org/bytes/0"
+        static let randomBytes = "https://httpbin.org/bytes/\(4 * 1024 * 1024)"
+        static let json = "https://httpbin.org/get"
+        
+        static let gravatarImages: [String] = [
+            "https://secure.gravatar.com/avatar/5a105e8b9d40e1329780d62ea2265d8a?d=identicon",
+            "https://secure.gravatar.com/avatar/6a105e8b9d40e1329780d62ea2265d8a?d=identicon",
+            "https://secure.gravatar.com/avatar/7a105e8b9d40e1329780d62ea2265d8a?d=identicon",
+            "https://secure.gravatar.com/avatar/8a105e8b9d40e1329780d62ea2265d8a?d=identicon",
+            "https://secure.gravatar.com/avatar/9a105e8b9d40e1329780d62ea2265d8a?d=identicon"
+        ]
+        
+        static var randomJPEGImage: String {
+            "https://httpbin.org/image/jpeg?random=\(arc4random())"
+        }
+        
+        static var kittenImageOfRandomSize: String {
+            let width = Int.random(in: 100...400)
+            let height = Int.random(in: 100...400)
+            
+            let urlString = "https://placekitten.com/\(width)/\(height)"
+            return urlString
+        }
+        
+        static let nonExistent = "https://invalid.for.sure"
+    }
+}

--- a/Tests/UIButtonTests.swift
+++ b/Tests/UIButtonTests.swift
@@ -55,7 +55,7 @@ private class TestButton: UIButton {
 // MARK: -
 
 class UIButtonTests: BaseTestCase {
-    let url = URL(string: "https://httpbin.org/image/jpeg")!
+    let url = URL(string: TestEnvironment.URL.jpegImage)!
 
     // MARK: - Setup and Teardown
 
@@ -206,7 +206,7 @@ class UIButtonTests: BaseTestCase {
 
         let expectation2 = expectation(description: "background image should download successfully")
         var selectedStateImageDownloadComplete = false
-        url = URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
+        url = URL(string: TestEnvironment.URL.randomJPEGImage)!
 
         button.af.setImage(for: [.selected], url: url)
         button.imageObserver = {
@@ -218,7 +218,7 @@ class UIButtonTests: BaseTestCase {
 
         let expectation3 = expectation(description: "background image should download successfully")
         var highlightedStateImageDownloadComplete = false
-        url = URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
+        url = URL(string: TestEnvironment.URL.randomJPEGImage)!
 
         button.af.setImage(for: [.highlighted], url: url)
         button.imageObserver = {
@@ -230,7 +230,7 @@ class UIButtonTests: BaseTestCase {
 
         let expectation4 = expectation(description: "background image should download successfully")
         var disabledStateImageDownloadComplete = false
-        url = URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
+        url = URL(string: TestEnvironment.URL.randomJPEGImage)!
 
         button.af.setImage(for: [.disabled], url: url)
         button.imageObserver = {
@@ -271,7 +271,7 @@ class UIButtonTests: BaseTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
         let expectation2 = expectation(description: "background image should download successfully")
         var selectedStateBackgroundImageDownloadComplete = false
-        url = URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
+        url = URL(string: TestEnvironment.URL.randomJPEGImage)!
 
         button.af.setBackgroundImage(for: [.selected], url: url)
         button.imageObserver = {
@@ -283,7 +283,7 @@ class UIButtonTests: BaseTestCase {
 
         let expectation3 = expectation(description: "background image should download successfully")
         var highlightedStateBackgroundImageDownloadComplete = false
-        url = URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
+        url = URL(string: TestEnvironment.URL.randomJPEGImage)!
 
         button.af.setBackgroundImage(for: [.highlighted], url: url)
         button.imageObserver = {
@@ -295,7 +295,7 @@ class UIButtonTests: BaseTestCase {
 
         let expectation4 = expectation(description: "background image should download successfully")
         var disabledStateBackgroundImageDownloadComplete = false
-        url = URL(string: "https://httpbin.org/image/jpeg?random=\(arc4random())")!
+        url = URL(string: TestEnvironment.URL.randomJPEGImage)!
 
         button.af.setBackgroundImage(for: [.disabled], url: url)
         button.imageObserver = {
@@ -917,7 +917,7 @@ class UIButtonTests: BaseTestCase {
             })
 
         button.af.setImage(for: [],
-                           urlRequest: URLRequest(url: URL(string: "https://httpbin.org/image/png")!),
+                           urlRequest: URLRequest(url: URL(string: TestEnvironment.URL.pngImage)!),
                            placeholderImage: nil,
                            completion: { closureResponse in
                                completion2Called = true
@@ -952,7 +952,7 @@ class UIButtonTests: BaseTestCase {
             })
 
         button.af.setBackgroundImage(for: [],
-                                     urlRequest: URLRequest(url: URL(string: "https://httpbin.org/image/png")!),
+                                     urlRequest: URLRequest(url: URL(string: TestEnvironment.URL.pngImage)!),
                                      placeholderImage: nil,
                                      completion: { closureResponse in
                                          completion2Called = true
@@ -1099,8 +1099,7 @@ class UIButtonTests: BaseTestCase {
 
     func testThatImageBehindRedirectCanBeDownloaded() {
         // Given
-        let redirectURLString = "https://httpbin.org/image/png"
-        let url = URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
+        let url = URL(string: TestEnvironment.URL.pngImageWithRedirect)!
 
         let expectation = self.expectation(description: "image should download successfully")
         var imageDownloadComplete = false
@@ -1121,8 +1120,7 @@ class UIButtonTests: BaseTestCase {
 
     func testThatBackgroundImageBehindRedirectCanBeDownloaded() {
         // Given
-        let redirectURLString = "https://httpbin.org/image/png"
-        let url = URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
+        let url = URL(string: TestEnvironment.URL.pngImageWithRedirect)!
 
         let expectation = self.expectation(description: "image should download successfully")
         var backgroundImageDownloadComplete = false

--- a/Tests/UIImageViewTests.swift
+++ b/Tests/UIImageViewTests.swift
@@ -60,7 +60,7 @@ private class TestImageView: UIImageView {
 // MARK: -
 
 class UIImageViewTestCase: BaseTestCase {
-    let url = URL(string: "https://httpbin.org/image/jpeg")!
+    let url = URL(string: TestEnvironment.URL.jpegImage)!
 
     // MARK: - Setup and Teardown
 
@@ -190,7 +190,7 @@ class UIImageViewTestCase: BaseTestCase {
         let imageView = UIImageView()
 
         let downloader = ImageDownloader.default
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         downloader.download(urlRequest) { _ in
@@ -212,7 +212,7 @@ class UIImageViewTestCase: BaseTestCase {
         let imageView = UIImageView()
 
         let downloader = ImageDownloader.default
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
         let expectation = self.expectation(description: "image download should succeed")
 
         downloader.download(urlRequest, filter: CircleFilter()) { _ in
@@ -311,7 +311,7 @@ class UIImageViewTestCase: BaseTestCase {
         let imageView = UIImageView()
 
         let downloader = ImageDownloader.default
-        let urlRequest = try! URLRequest(url: "https://httpbin.org/image/jpeg", method: .get)
+        let urlRequest = try! URLRequest(url: TestEnvironment.URL.jpegImage, method: .get)
         let expectation = self.expectation(description: "image download should succeed")
         downloader.download(urlRequest) { _ in
             expectation.fulfill()
@@ -669,7 +669,7 @@ class UIImageViewTestCase: BaseTestCase {
                                   completion1Called = true
             })
 
-        imageView.af.setImage(withURLRequest: URLRequest(url: URL(string: "https://httpbin.org/image/png")!),
+        imageView.af.setImage(withURLRequest: URLRequest(url: URL(string: TestEnvironment.URL.pngImage)!),
                               placeholderImage: nil,
                               filter: nil,
                               imageTransition: .noTransition,
@@ -756,8 +756,7 @@ class UIImageViewTestCase: BaseTestCase {
 
     func testThatImageBehindRedirectCanBeDownloaded() {
         // Given
-        let redirectURLString = "https://httpbin.org/image/png"
-        let url = URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
+        let url = URL(string: TestEnvironment.URL.pngImageWithRedirect)!
 
         let expectation = self.expectation(description: "image should download successfully")
         var imageDownloadComplete = false


### PR DESCRIPTION
### Goals :soccer:
Improve maintainability of the test suite

### Implementation Details :construction:
I noticed a significant amount of copy-pasted urls throughout the test suite. It makes it hard to change the urls, should it become necessary to migrate to another service or use a locally running version of httpbin. 
This PR introduces a `TestEnvironment` namespace which contains a collection of urls used in the suite. More relevant data can be added under this namespace in the future, if needed.  

### Testing Details :mag:
The tests have been modified in a minor way that doesn't change their behaviour. 