### PR TITLE
Fix for invalid file url to file path conversion

### DIFF
--- a/Source/ImageDownloader.swift
+++ b/Source/ImageDownloader.swift
@@ -169,7 +169,7 @@ open class ImageDownloader {
         #if os(macOS)
         return URLCache(memoryCapacity: memoryCapacity,
                         diskCapacity: diskCapacity,
-                        diskPath: cacheDirectory?.appendingPathComponent(imageDownloaderPath).absoluteString)
+                        diskPath: cacheDirectory?.appendingPathComponent(imageDownloaderPath).path)
         #else
         return URLCache(memoryCapacity: memoryCapacity,
                         diskCapacity: diskCapacity,


### PR DESCRIPTION
### Goals :soccer:

The default configuration of the url cache directory in `ImageDownloader` is broken. This pull request fixes it.

### Implementation Details :construction:

`URL.absoluteString` returns `file:///my/path` for file URLs. We have to use `URL.path` instead. 