### PR TITLE
Add heic image type to the image response serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The AlamofireImage response image serializers support a wide range of image type
 - `image/x-xbitmap`
 - `image/x-ms-bmp`
 - `image/x-win-bitmap`
+- `image/heic`
 - `application/octet-stream` (added for iOS 13 support)
 
 > If the image you are attempting to download is an invalid MIME type not in the list, you can add custom acceptable content types using the `addAcceptableImageContentTypes` extension on the `DataRequest` type.

--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -55,7 +55,8 @@ public final class ImageResponseSerializer: ResponseSerializer {
                                                            "image/x-bmp",
                                                            "image/x-xbitmap",
                                                            "image/x-ms-bmp",
-                                                           "image/x-win-bitmap"]
+                                                           "image/x-win-bitmap",
+                                                           "image/heic"]
 
     static let streamImageInitialBytePattern = Data([255, 216]) // 0xffd8
 

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -54,8 +54,8 @@ class DataRequestTestCase: BaseTestCase {
         let afterCount = ImageResponseSerializer.acceptableImageContentTypes.count
 
         // Then
-        XCTAssertEqual(beforeCount, 12, "before count should be 12")
-        XCTAssertEqual(afterCount, 14, "after count should be 14")
+        XCTAssertEqual(beforeCount, 13, "before count should be 13")
+        XCTAssertEqual(afterCount, 15, "after count should be 15")
     }
 
     // MARK: - Tests - Image Serialization


### PR DESCRIPTION
### Goals :soccer:
The goal is to be able to download heic images without having to ensure that the type is manually added to the image response serializer. Heic is a native format created by Apple that is growing in popularity.
