### PR TITLE
Disable redirect tests, update CI to Xcode 11.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     name: Test macOS (5.2)
     runs-on: macOS-latest
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.6.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
   #   name: Test Catalyst
   #   runs-on: macOS-latest
   #   env:
-  #     DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+  #     DEVELOPER_DIR: /Applications/Xcode_11.6.app/Contents/Developer
   #   steps:
   #     - uses: actions/checkout@v2
   #     - name: Dependencies
@@ -49,10 +49,10 @@ jobs:
     name: Test iOS 
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.6.app/Contents/Developer
     strategy:
       matrix:
-        destination: ["OS=13.4,name=iPhone 11 Pro"]
+        destination: ["OS=13.6,name=iPhone 11 Pro"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -64,7 +64,7 @@ jobs:
     name: Test tvOS 
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.6.app/Contents/Developer
     strategy:
       matrix:
         destination: ["OS=13.4,name=Apple TV 4K"]
@@ -79,10 +79,10 @@ jobs:
     name: Build watchOS
     runs-on: macOS-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.6.app/Contents/Developer
     strategy:
       matrix:
-        destination: ["OS=6.2,name=Apple Watch Series 5 - 44mm"]
+        destination: ["OS=6.2.1,name=Apple Watch Series 5 - 44mm"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -94,7 +94,7 @@ jobs:
     name: Build with SPM
     runs-on: macOS-latest    
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_11.6.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: SPM Build

--- a/Tests/UIButtonTests.swift
+++ b/Tests/UIButtonTests.swift
@@ -1096,50 +1096,50 @@ class UIButtonTests: BaseTestCase {
     }
 
     // MARK: - Redirects
-
-    func testThatImageBehindRedirectCanBeDownloaded() {
-        // Given
-        let redirectURLString = "https://httpbin.org/image/png"
-        let url = URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
-
-        let expectation = self.expectation(description: "image should download successfully")
-        var imageDownloadComplete = false
-
-        let button = TestButton {
-            imageDownloadComplete = true
-            expectation.fulfill()
-        }
-
-        // When
-        button.af.setImage(for: [], url: url)
-        waitForExpectations(timeout: timeout, handler: nil)
-
-        // Then
-        XCTAssertTrue(imageDownloadComplete, "image download complete should be true")
-        XCTAssertNotNil(button.image(for: []), "button image should not be nil")
-    }
-
-    func testThatBackgroundImageBehindRedirectCanBeDownloaded() {
-        // Given
-        let redirectURLString = "https://httpbin.org/image/png"
-        let url = URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
-
-        let expectation = self.expectation(description: "image should download successfully")
-        var backgroundImageDownloadComplete = false
-
-        let button = TestButton {
-            backgroundImageDownloadComplete = true
-            expectation.fulfill()
-        }
-
-        // When
-        button.af.setBackgroundImage(for: [], url: url)
-        waitForExpectations(timeout: timeout, handler: nil)
-
-        // Then
-        XCTAssertTrue(backgroundImageDownloadComplete, "image download complete should be true")
-        XCTAssertNotNil(button.backgroundImage(for: []), "button background image should not be nil")
-    }
+// Disable redirect tests due to HTTPBin failures.
+//    func testThatImageBehindRedirectCanBeDownloaded() {
+//        // Given
+//        let redirectURLString = "https://httpbin.org/image/png"
+//        let url = URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
+//
+//        let expectation = self.expectation(description: "image should download successfully")
+//        var imageDownloadComplete = false
+//
+//        let button = TestButton {
+//            imageDownloadComplete = true
+//            expectation.fulfill()
+//        }
+//
+//        // When
+//        button.af.setImage(for: [], url: url)
+//        waitForExpectations(timeout: timeout, handler: nil)
+//
+//        // Then
+//        XCTAssertTrue(imageDownloadComplete, "image download complete should be true")
+//        XCTAssertNotNil(button.image(for: []), "button image should not be nil")
+//    }
+//
+//    func testThatBackgroundImageBehindRedirectCanBeDownloaded() {
+//        // Given
+//        let redirectURLString = "https://httpbin.org/image/png"
+//        let url = URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
+//
+//        let expectation = self.expectation(description: "image should download successfully")
+//        var backgroundImageDownloadComplete = false
+//
+//        let button = TestButton {
+//            backgroundImageDownloadComplete = true
+//            expectation.fulfill()
+//        }
+//
+//        // When
+//        button.af.setBackgroundImage(for: [], url: url)
+//        waitForExpectations(timeout: timeout, handler: nil)
+//
+//        // Then
+//        XCTAssertTrue(backgroundImageDownloadComplete, "image download complete should be true")
+//        XCTAssertNotNil(button.backgroundImage(for: []), "button background image should not be nil")
+//    }
 
     // MARK: - Accept Header
 

--- a/Tests/UIImageViewTests.swift
+++ b/Tests/UIImageViewTests.swift
@@ -753,28 +753,28 @@ class UIImageViewTestCase: BaseTestCase {
     }
 
     // MARK: - Redirects
-
-    func testThatImageBehindRedirectCanBeDownloaded() {
-        // Given
-        let redirectURLString = "https://httpbin.org/image/png"
-        let url = URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
-
-        let expectation = self.expectation(description: "image should download successfully")
-        var imageDownloadComplete = false
-
-        let imageView = TestImageView {
-            imageDownloadComplete = true
-            expectation.fulfill()
-        }
-
-        // When
-        imageView.af.setImage(withURL: url)
-        waitForExpectations(timeout: timeout, handler: nil)
-
-        // Then
-        XCTAssertTrue(imageDownloadComplete, "image download complete should be true")
-        XCTAssertNotNil(imageView.image, "image view image should not be nil")
-    }
+// Disable redirect tests due to HTTPBin failures.
+//    func testThatImageBehindRedirectCanBeDownloaded() {
+//        // Given
+//        let redirectURLString = "https://httpbin.org/image/png"
+//        let url = URL(string: "https://httpbin.org/redirect-to?url=\(redirectURLString)")!
+//
+//        let expectation = self.expectation(description: "image should download successfully")
+//        var imageDownloadComplete = false
+//
+//        let imageView = TestImageView {
+//            imageDownloadComplete = true
+//            expectation.fulfill()
+//        }
+//
+//        // When
+//        imageView.af.setImage(withURL: url)
+//        waitForExpectations(timeout: timeout, handler: nil)
+//
+//        // Then
+//        XCTAssertTrue(imageDownloadComplete, "image download complete should be true")
+//        XCTAssertNotNil(imageView.image, "image view image should not be nil")
+//    }
 
     // MARK: - Accept Header
 


### PR DESCRIPTION
### Goals :soccer:
This PR disables our redirect tests, as HTTPBin is still broken, and updates the GitHub actions to use Xcode 11.6.
