### PR TITLE
Use accept header that is sorted for default header.

### DIFF
--- a/Source/UIButton+AlamofireImage.swift
+++ b/Source/UIButton+AlamofireImage.swift
@@ -487,7 +487,7 @@ extension AlamofireExtension where ExtendedType: UIButton {
     private func urlRequest(with url: URL) -> URLRequest {
         var urlRequest = URLRequest(url: url)
 
-        for mimeType in ImageResponseSerializer.acceptableImageContentTypes {
+        for mimeType in ImageResponseSerializer.acceptableImageContentTypes.sorted() {
             urlRequest.addValue(mimeType, forHTTPHeaderField: "Accept")
         }
 

--- a/Source/UIImageView+AlamofireImage.swift
+++ b/Source/UIImageView+AlamofireImage.swift
@@ -398,7 +398,7 @@ extension AlamofireExtension where ExtendedType: UIImageView {
     private func urlRequest(with url: URL) -> URLRequest {
         var urlRequest = URLRequest(url: url)
 
-        for mimeType in ImageResponseSerializer.acceptableImageContentTypes {
+        for mimeType in ImageResponseSerializer.acceptableImageContentTypes.sorted() {
             urlRequest.addValue(mimeType, forHTTPHeaderField: "Accept")
         }
 

--- a/Tests/UIButtonTests.swift
+++ b/Tests/UIButtonTests.swift
@@ -1156,7 +1156,7 @@ class UIButtonTests: BaseTestCase {
         XCTAssertNotNil(acceptField)
 
         if let acceptField = acceptField {
-            XCTAssertEqual(acceptField, ImageResponseSerializer.acceptableImageContentTypes.joined(separator: ","))
+            XCTAssertEqual(acceptField, ImageResponseSerializer.acceptableImageContentTypes.sorted().joined(separator: ","))
         }
     }
 }

--- a/Tests/UIImageViewTests.swift
+++ b/Tests/UIImageViewTests.swift
@@ -799,7 +799,7 @@ class UIImageViewTestCase: BaseTestCase {
 
         if let acceptField = acceptField {
             print(acceptField)
-            XCTAssertEqual(acceptField, ImageResponseSerializer.acceptableImageContentTypes.joined(separator: ","))
+            XCTAssertEqual(acceptField, ImageResponseSerializer.acceptableImageContentTypes.sorted().joined(separator: ","))
         }
     }
 }


### PR DESCRIPTION
### Goals :soccer:
I'm building an image storage SaaS and using a CDN.
One of my clients is using this library and the AcceptHeader changes every time.
So the CDN cache doesn't work effectively.

### Implementation Details :construction:
I change the order of the Accept Header to sort before return it.

### Testing Details :mag:
I've modified it to test the sorted accept header.
Please let me know what kind of test I should do if needed other cases.
