### PR TITLE
setImage reflects URLRequest.CachePolicy

### DIFF
--- a/Source/UIButton+AlamofireImage.swift
+++ b/Source/UIButton+AlamofireImage.swift
@@ -184,9 +184,18 @@ extension AlamofireExtension where ExtendedType: UIButton {
 
         let imageDownloader = self.imageDownloader ?? UIButton.af.sharedImageDownloader
         let imageCache = imageDownloader.imageCache
+        
+        let useCache: Bool = {
+            switch urlRequest.urlRequest?.cachePolicy {
+            case .useProtocolCachePolicy, .returnCacheDataElseLoad, .returnCacheDataDontLoad:
+                return true
+            default:
+                return false
+            }
+        }()
 
         // Use the image from the image cache if it exists
-        if let request = urlRequest.urlRequest {
+        if let request = urlRequest.urlRequest, useCache {
             let cachedImage: Image?
 
             if let cacheKey = cacheKey {
@@ -353,9 +362,18 @@ extension AlamofireExtension where ExtendedType: UIButton {
 
         let imageDownloader = self.imageDownloader ?? UIButton.af.sharedImageDownloader
         let imageCache = imageDownloader.imageCache
+        
+        let useCache: Bool = {
+            switch urlRequest.urlRequest?.cachePolicy {
+            case .useProtocolCachePolicy, .returnCacheDataElseLoad, .returnCacheDataDontLoad:
+                return true
+            default:
+                return false
+            }
+        }()
 
         // Use the image from the image cache if it exists
-        if let request = urlRequest.urlRequest {
+        if let request = urlRequest.urlRequest, useCache {
             let cachedImage: Image?
 
             if let cacheKey = cacheKey {

--- a/Source/UIImageView+AlamofireImage.swift
+++ b/Source/UIImageView+AlamofireImage.swift
@@ -284,9 +284,18 @@ extension AlamofireExtension where ExtendedType: UIImageView {
 
         let imageDownloader = self.imageDownloader ?? UIImageView.af.sharedImageDownloader
         let imageCache = imageDownloader.imageCache
+        
+        let useCache: Bool = {
+            switch urlRequest.urlRequest?.cachePolicy {
+            case .useProtocolCachePolicy, .returnCacheDataElseLoad, .returnCacheDataDontLoad:
+                return true
+            default:
+                return false
+            }
+        }()
 
         // Use the image from the image cache if it exists
-        if let request = urlRequest.urlRequest {
+        if let request = urlRequest.urlRequest, useCache {
             let cachedImage: Image?
 
             if let cacheKey = cacheKey {


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
#302 

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
We can force setImage to get image from origin.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
[before]
If we set CachePolicy to URLRequest when calling setImage(withUrlRequest:), setImage always don't get from origin, but from imageCache.

[after]
setImage reflect CachePolicy setting.
(.reloadIgnoringLocalCacheData -> setImage don't use imageCache, always get origin.  )

Conditions to refer to ImageCache match ImageDownloader.download.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
add no testing