### PR TITLE
Add open modifier for ImageResponseSerializer

### DIFF
--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -89,7 +89,7 @@ open class ImageResponseSerializer: ResponseSerializer {
 
     // MARK: Serialization
 
-    public func serialize(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: Error?) throws -> Image {
+    open func serialize(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: Error?) throws -> Image {
         guard error == nil else { throw error! }
 
         guard let data = data, !data.isEmpty else {

--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -34,7 +34,7 @@ import WatchKit
 import Cocoa
 #endif
 
-public final class ImageResponseSerializer: ResponseSerializer {
+open class ImageResponseSerializer: ResponseSerializer {
     // MARK: Properties
 
     public static var deviceScreenScale: CGFloat { DataRequest.imageScale }
@@ -107,7 +107,7 @@ public final class ImageResponseSerializer: ResponseSerializer {
         return image
     }
 
-    public func serializeImage(from data: Data) throws -> Image {
+    open func serializeImage(from data: Data) throws -> Image {
         guard !data.isEmpty else {
             throw AFError.responseSerializationFailed(reason: .inputDataNilOrZeroLength)
         }


### PR DESCRIPTION
### Goals :soccer:
Ability to use a custom `ImageResponseSerializer`, for example, downsampling image

### Implementation Details :construction:
add `open` for `class ImageResponseSerializer`
add `open` for `serializeImage(from data: Data)` 
add `open` for `serialize(request: URLRequest?, response: HTTPURLResponse?, data: Data?, error: Error?) -> Image`
