### PR TITLE
Expose acceptableImageContentTypes

### DIFF
--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -44,7 +44,7 @@ public final class ImageResponseSerializer: ResponseSerializer {
     public let emptyResponseCodes: Set<Int>
     public let emptyRequestMethods: Set<HTTPMethod>
 
-    static var acceptableImageContentTypes: Set<String> = {
+    public internal(set) static var acceptableImageContentTypes: Set<String> = {
         var contentTypes: Set<String> = ["application/octet-stream",
                                          "image/tiff",
                                          "image/jpg",


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
Expose `ImageResponseSerializer.acceptableImageContentTypes` for read-only consumption by API consumers.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
I have had a few instances where I need to express valid content types. 
The most recent use case was within a SwiftUI view where I wanted to download an image directly.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
n/a