### PR TITLE
Resolves Issue 465 Incorrect associatedObject use generates Xcode warnings

### DIFF
--- a/AlamofireImage.xcodeproj/project.pbxproj
+++ b/AlamofireImage.xcodeproj/project.pbxproj
@@ -13,6 +13,10 @@
 		31FA4D7926192E4500CEAD2B /* CGSize.ScreenScaling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FA4D7826192E4500CEAD2B /* CGSize.ScreenScaling.swift */; };
 		31FA4D7A26192E4500CEAD2B /* CGSize.ScreenScaling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FA4D7826192E4500CEAD2B /* CGSize.ScreenScaling.swift */; };
 		31FA4D7B26192E4500CEAD2B /* CGSize.ScreenScaling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FA4D7826192E4500CEAD2B /* CGSize.ScreenScaling.swift */; };
+		49B2E0622A7B1C3D00797C38 /* UniqueAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B2E0612A7B1C3D00797C38 /* UniqueAddress.swift */; };
+		49B2E0632A7B1C3D00797C38 /* UniqueAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B2E0612A7B1C3D00797C38 /* UniqueAddress.swift */; };
+		49B2E0642A7B1C3D00797C38 /* UniqueAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B2E0612A7B1C3D00797C38 /* UniqueAddress.swift */; };
+		49B2E0652A7B1C3D00797C38 /* UniqueAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B2E0612A7B1C3D00797C38 /* UniqueAddress.swift */; };
 		4C0893EC1B936A7A005125D9 /* UIImage+AlamofireImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0893EB1B936A7A005125D9 /* UIImage+AlamofireImageTests.swift */; };
 		4C0893F51B937404005125D9 /* UIImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0893F41B937404005125D9 /* UIImageTests.swift */; };
 		4C0894E41B9382EB005125D9 /* apple.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 4C0894501B9382EB005125D9 /* apple.jpg */; };
@@ -574,6 +578,7 @@
 		314354501F4A16FE00266E5F /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		31FA4D662619207200CEAD2B /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		31FA4D7826192E4500CEAD2B /* CGSize.ScreenScaling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGSize.ScreenScaling.swift; sourceTree = "<group>"; };
+		49B2E0612A7B1C3D00797C38 /* UniqueAddress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniqueAddress.swift; sourceTree = "<group>"; };
 		4C0893EB1B936A7A005125D9 /* UIImage+AlamofireImageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+AlamofireImageTests.swift"; sourceTree = "<group>"; };
 		4C0893F41B937404005125D9 /* UIImageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageTests.swift; sourceTree = "<group>"; };
 		4C0894501B9382EB005125D9 /* apple.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = apple.jpg; sourceTree = "<group>"; };
@@ -1283,6 +1288,7 @@
 		4CF6CC5D1AAD2822007A38CB /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				49B2E0612A7B1C3D00797C38 /* UniqueAddress.swift */,
 				CF24CF411C253CB100904E85 /* UIButton+AlamofireImage.swift */,
 				4C53084F1AB561BF0051DBAC /* UIImage+AlamofireImage.swift */,
 				4C78EA711AACD28C002C0569 /* UIImageView+AlamofireImage.swift */,
@@ -2047,6 +2053,7 @@
 				4CD5BCEC1D7F9D1E0055E232 /* AFIError.swift in Sources */,
 				4C16B3A61BA93AB700A66EF0 /* UIImageView+AlamofireImage.swift in Sources */,
 				4C16B3A41BA93AB700A66EF0 /* Request+AlamofireImage.swift in Sources */,
+				49B2E0642A7B1C3D00797C38 /* UniqueAddress.swift in Sources */,
 				4C16B3A51BA93AB700A66EF0 /* UIImage+AlamofireImage.swift in Sources */,
 				4C16B3A31BA93AB700A66EF0 /* ImageFilter.swift in Sources */,
 				4C16B3A21BA93AB700A66EF0 /* ImageDownloader.swift in Sources */,
@@ -2085,6 +2092,7 @@
 				4CD5BCED1D7F9D1E0055E232 /* AFIError.swift in Sources */,
 				4C86C10E1DA0B3160032ECC3 /* UIImageView+AlamofireImage.swift in Sources */,
 				4C4D4ECE1B9297BB00C96855 /* Request+AlamofireImage.swift in Sources */,
+				49B2E0652A7B1C3D00797C38 /* UniqueAddress.swift in Sources */,
 				4C4D4ECF1B9297BB00C96855 /* UIImage+AlamofireImage.swift in Sources */,
 				4C4D4ECD1B9297BB00C96855 /* ImageFilter.swift in Sources */,
 				4C4D4ECC1B9297BB00C96855 /* ImageDownloader.swift in Sources */,
@@ -2101,6 +2109,7 @@
 				4CD5BCEA1D7F9D1E0055E232 /* AFIError.swift in Sources */,
 				4CFC0A091AB52BD90004D0B8 /* ImageFilter.swift in Sources */,
 				CF24CF421C253CB100904E85 /* UIButton+AlamofireImage.swift in Sources */,
+				49B2E0622A7B1C3D00797C38 /* UniqueAddress.swift in Sources */,
 				4C78EA721AACD28C002C0569 /* UIImageView+AlamofireImage.swift in Sources */,
 				4C5308501AB561BF0051DBAC /* UIImage+AlamofireImage.swift in Sources */,
 				4CFC0A061AB4FEC90004D0B8 /* ImageCache.swift in Sources */,
@@ -2139,6 +2148,7 @@
 				4C82907B1B927CE6005E24C8 /* Image.swift in Sources */,
 				4C86C10D1DA0B3150032ECC3 /* UIImageView+AlamofireImage.swift in Sources */,
 				4C82907C1B927D13005E24C8 /* ImageDownloader.swift in Sources */,
+				49B2E0632A7B1C3D00797C38 /* UniqueAddress.swift in Sources */,
 				4CE611561AABC8D900D35044 /* Request+AlamofireImage.swift in Sources */,
 				4CD5BCEB1D7F9D1E0055E232 /* AFIError.swift in Sources */,
 				4C86C10C1DA0B3110032ECC3 /* UIImage+AlamofireImage.swift in Sources */,

--- a/Source/UIButton+AlamofireImage.swift
+++ b/Source/UIButton+AlamofireImage.swift
@@ -40,10 +40,10 @@ extension AlamofireExtension where ExtendedType: UIButton {
     /// custom instance image downloader is when images are behind different basic auth credentials.
     public var imageDownloader: ImageDownloader? {
         get {
-            objc_getAssociatedObject(type, &AssociatedKeys.imageDownloader) as? ImageDownloader
+            objc_getAssociatedObject(type, AssociatedKeys.imageDownloader) as? ImageDownloader
         }
         nonmutating set {
-            objc_setAssociatedObject(type, &AssociatedKeys.imageDownloader, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(type, AssociatedKeys.imageDownloader, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
@@ -54,39 +54,39 @@ extension AlamofireExtension where ExtendedType: UIButton {
     public static var sharedImageDownloader: ImageDownloader {
         get {
             guard let
-                downloader = objc_getAssociatedObject(UIButton.self, &AssociatedKeys.sharedImageDownloader) as? ImageDownloader
+                downloader = objc_getAssociatedObject(UIButton.self, AssociatedKeys.sharedImageDownloader) as? ImageDownloader
             else { return ImageDownloader.default }
 
             return downloader
         }
         set {
-            objc_setAssociatedObject(UIButton.self, &AssociatedKeys.sharedImageDownloader, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(UIButton.self, AssociatedKeys.sharedImageDownloader, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
     private var imageRequestReceipts: [UInt: RequestReceipt] {
         get {
             guard let
-                receipts = objc_getAssociatedObject(type, &AssociatedKeys.imageReceipts) as? [UInt: RequestReceipt]
+                receipts = objc_getAssociatedObject(type, AssociatedKeys.imageReceipts) as? [UInt: RequestReceipt]
             else { return [:] }
 
             return receipts
         }
         nonmutating set {
-            objc_setAssociatedObject(type, &AssociatedKeys.imageReceipts, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(type, AssociatedKeys.imageReceipts, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
     private var backgroundImageRequestReceipts: [UInt: RequestReceipt] {
         get {
             guard let
-                receipts = objc_getAssociatedObject(type, &AssociatedKeys.backgroundImageReceipts) as? [UInt: RequestReceipt]
+                receipts = objc_getAssociatedObject(type, AssociatedKeys.backgroundImageReceipts) as? [UInt: RequestReceipt]
             else { return [:] }
 
             return receipts
         }
         nonmutating set {
-            objc_setAssociatedObject(type, &AssociatedKeys.backgroundImageReceipts, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(type, AssociatedKeys.backgroundImageReceipts, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
@@ -608,10 +608,10 @@ extension UIButton {
 // MARK: - Private - AssociatedKeys
 
 private enum AssociatedKeys {
-    static var imageDownloader = "UIButton.af.imageDownloader"
-    static var sharedImageDownloader = "UIButton.af.sharedImageDownloader"
-    static var imageReceipts = "UIButton.af.imageReceipts"
-    static var backgroundImageReceipts = "UIButton.af.backgroundImageReceipts"
+    @UniqueAddress static var imageDownloader
+    @UniqueAddress static var sharedImageDownloader
+    @UniqueAddress static var imageReceipts
+    @UniqueAddress static var backgroundImageReceipts
 }
 
 #endif

--- a/Source/UIImage+AlamofireImage.swift
+++ b/Source/UIImage+AlamofireImage.swift
@@ -91,14 +91,14 @@ extension AlamofireExtension where ExtendedType: UIImage {
     /// Returns whether the image is inflated.
     public var isInflated: Bool {
         get {
-            if let isInflated = objc_getAssociatedObject(type, &AssociatedKeys.isInflated) as? Bool {
+            if let isInflated = objc_getAssociatedObject(type, AssociatedKeys.isInflated) as? Bool {
                 return isInflated
             } else {
                 return false
             }
         }
         nonmutating set {
-            objc_setAssociatedObject(type, &AssociatedKeys.isInflated, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(type, AssociatedKeys.isInflated, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
@@ -391,5 +391,5 @@ extension UIImage {
 // MARK: -
 
 private enum AssociatedKeys {
-    static var isInflated = "UIImage.af.isInflated"
+    @UniqueAddress static var isInflated
 }

--- a/Source/UIImageView+AlamofireImage.swift
+++ b/Source/UIImageView+AlamofireImage.swift
@@ -128,10 +128,10 @@ extension AlamofireExtension where ExtendedType: UIImageView {
     /// instance image downloader is when images are behind different basic auth credentials.
     public var imageDownloader: ImageDownloader? {
         get {
-            objc_getAssociatedObject(type, &AssociatedKeys.imageDownloader) as? ImageDownloader
+            objc_getAssociatedObject(type, AssociatedKeys.imageDownloader) as? ImageDownloader
         }
         nonmutating set(downloader) {
-            objc_setAssociatedObject(type, &AssociatedKeys.imageDownloader, downloader, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(type, AssociatedKeys.imageDownloader, downloader, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
@@ -141,23 +141,23 @@ extension AlamofireExtension where ExtendedType: UIImageView {
     /// `imageDownloader` is `nil`.
     public static var sharedImageDownloader: ImageDownloader {
         get {
-            if let downloader = objc_getAssociatedObject(UIImageView.self, &AssociatedKeys.sharedImageDownloader) as? ImageDownloader {
+            if let downloader = objc_getAssociatedObject(UIImageView.self, AssociatedKeys.sharedImageDownloader) as? ImageDownloader {
                 return downloader
             } else {
                 return ImageDownloader.default
             }
         }
         set {
-            objc_setAssociatedObject(UIImageView.self, &AssociatedKeys.sharedImageDownloader, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(UIImageView.self, AssociatedKeys.sharedImageDownloader, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
     var activeRequestReceipt: RequestReceipt? {
         get {
-            objc_getAssociatedObject(type, &AssociatedKeys.activeRequestReceipt) as? RequestReceipt
+            objc_getAssociatedObject(type, AssociatedKeys.activeRequestReceipt) as? RequestReceipt
         }
         nonmutating set {
-            objc_setAssociatedObject(type, &AssociatedKeys.activeRequestReceipt, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(type, AssociatedKeys.activeRequestReceipt, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
@@ -492,9 +492,9 @@ extension UIImageView {
 // MARK: -
 
 private enum AssociatedKeys {
-    static var imageDownloader = "UIImageView.af.imageDownloader"
-    static var sharedImageDownloader = "UIImageView.af.sharedImageDownloader"
-    static var activeRequestReceipt = "UIImageView.af.activeRequestReceipt"
+    @UniqueAddress static var imageDownloader
+    @UniqueAddress static var sharedImageDownloader
+    @UniqueAddress static var activeRequestReceipt
 }
 
 #endif

--- a/Source/UniqueAddress.swift
+++ b/Source/UniqueAddress.swift
@@ -1,0 +1,35 @@
+//
+//  UniqueAddress.swift
+//  AlamofireImage
+//
+//  Created by Andrew Benson on 8/1/23.
+//  Copyright © 2023 Alamofire. All rights reserved.
+//
+
+import Foundation
+
+/// From:
+/// https://github.com/atrick/swift-evolution/blob/diagnose-implicit-raw-bitwise/proposals/nnnn-implicit-raw-bitwise-conversion.md#workarounds-for-common-cases
+
+@propertyWrapper
+public struct UniqueAddress {
+    private var _placeholder: Int8 = 0
+
+    public var wrappedValue: UnsafeRawPointer {
+        mutating get {
+            // This is "ok" only as long as the wrapped property appears
+            // inside of something with a stable address (a global/static
+            // variable or class property) and the pointer is never read or
+            // written through, only used for its unique value
+            return withUnsafeBytes(of: &self) {
+                return $0.baseAddress.unsafelyUnwrapped
+            }
+        }
+    }
+
+    private init(_placeholder: Int8) {
+        self._placeholder = _placeholder
+    }
+
+    public init() { }
+}


### PR DESCRIPTION

### Issue Link :link:
[Issue 465 --Incorrect associatedObject use generates Xcode warnings](https://github.com/Alamofire/AlamofireImage/issues/465)

### Goals :soccer:
Clear Xcode 15 warnings

### Implementation Details :construction:
Implementation based primarily on the [work-around described in Swift Evolution](https://github.com/atrick/swift-evolution/blob/diagnose-implicit-raw-bitwise/proposals/nnnn-implicit-raw-bitwise-conversion.md#workarounds-for-common-cases).

### Testing Details :mag:
Build and run with Xcode 15.
